### PR TITLE
Add support for vertex finding in atmospheric samples

### DIFF
--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_Atmos_DUNEFD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_Atmos_DUNEFD.xml
@@ -1,0 +1,45 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArPreProcessing">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+    <algorithm type = "LArVisualMonitoring">
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</CaloHitListNames>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+
+    <algorithm type = "LArMaster">
+        <CRSettingsFile>PandoraSettings_Cosmic_DUNEFD.xml</CRSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_Atmos_DUNEFD.xml</NuSettingsFile>
+        <SlicingSettingsFile>PandoraSettings_Slicing_Standard.xml</SlicingSettingsFile>
+        <StitchingTools>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>false</ThreeDStitchingMode></tool>
+        </StitchingTools>
+        <CosmicRayTaggingTools>
+            <tool type = "LArCosmicRayTagging"/>
+        </CosmicRayTaggingTools>
+        <SliceIdTools>
+            <tool type = "LArSimpleNeutrinoId"/>
+        </SliceIdTools>
+        <InputHitListName>CaloHitList2D</InputHitListName>
+        <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
+        <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
+        <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
+        <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
+    </algorithm>
+
+    <algorithm type = "LArVisualMonitoring">
+        <ShowCurrentPfos>true</ShowCurrentPfos>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+</pandora>

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_Atmos_DUNEFD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_Atmos_DUNEFD.xml
@@ -101,8 +101,8 @@
         <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
         <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
         <MvaFileName>PandoraMVAData/PandoraBdt_Vertexing_DUNEFD_v03_27_00.xml</MvaFileName>
-        <RegionMvaName>DUNEFD_VertexSelectionRegion</RegionMvaName>
-        <VertexMvaName>DUNEFD_VertexSelectionVertex</VertexMvaName>
+        <RegionMvaName>DUNEFD_Atmos_VertexSelectionRegion</RegionMvaName>
+        <VertexMvaName>DUNEFD_Atmos_VertexSelectionVertex</VertexMvaName>
         <FeatureTools>
             <tool type = "LArEnergyKickFeature"/>
             <tool type = "LArLocalAsymmetryFeature"/>
@@ -111,6 +111,7 @@
             <tool type = "LArRPhiFeature"/>
             <tool type = "LArEnergyDepositionAsymmetryFeature"/>
         </FeatureTools>
+        <BeamMode>false</BeamMode>
         <LegacyEventShapes>false</LegacyEventShapes>
         <LegacyVariables>false</LegacyVariables>
     </algorithm>


### PR DESCRIPTION
This PR adds a new Pandora XML configuration for atmospheric neutrino samples that incorporates a vertex selection BDT that does not have a beam assumption (the standard DUNEFD XML configuration is also updated to refer to the new weights file in DUNE pardata, but the trees it uses are unchanged).

Note that this PR depends upon the larpandoracontent PR [38](https://github.com/LArSoft/larpandoracontent/pull/38).