### PR TITLE
update parameters for vd energy reco and change hitlabel to gaushit

### DIFF
--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/neutrinoenergyrecoalg_dune.fcl
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/neutrinoenergyrecoalg_dune.fcl
@@ -23,9 +23,26 @@ dune_neutrinoenergyrecoalg:
     RecombFactor:            0.63
 }
 
+dunevd_neutrinoenergyrecoalg:
+{
+    @table::dune_neutrinoenergyrecoalg
+    GradTrkMomRange:         412.0
+    IntTrkMomRange:          -28.24
+    GradTrkMomMCS:           1.093
+    IntTrkMomMCS:            0.074
+    GradNuMuHadEnCont:       0.554
+    IntNuMuHadEnCont:        -0.069
+    GradNuMuHadEnExit:	     0.532
+    IntNuMuHadEnExit:        -0.039
+    GradShwEnergy:           0.987
+    IntShwEnergy:            0.049
+    GradNuEHadEn:            0.428
+    IntNuEHadEn:             0.051
+}
+
 dune10kt_neutrinoenergyrecoalg: @local::dune_neutrinoenergyrecoalg
 
-dunevd10kt_neutrinoenergyrecoalg: @local::dune_neutrinoenergyrecoalg
+dunevd10kt_neutrinoenergyrecoalg: @local::dunevd_neutrinoenergyrecoalg
 dunevd10kt_neutrinoenergyrecoalg.CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
 
 END_PROLOG

--- a/dunereco/FDSensOpt/energyreco.fcl
+++ b/dunereco/FDSensOpt/energyreco.fcl
@@ -30,7 +30,7 @@ dunefd_nuenergyreco_pandora_numu:
     @table::dunefd_nuenergyreco_pmtrack
     RecoMethod:             1
     WireLabel:              "wclsdatanfsp:gauss"
-    HitLabel:               "pandora"
+    HitLabel:               "gaushit"
     TrackLabel:             "pandoraTrack"
     ShowerLabel:            "pandoraShower"
     TrackToHitLabel:        "pandoraTrack"


### PR DESCRIPTION
Two changes
1. update parameters for vd energy reco, which were reported at the FD Sim/Reco Meeting: https://indico.fnal.gov/event/53593/#14-neutrino-energy-reconstruct
2. change hitlabel from pandora which doesn't exist for hit to gaushit