### PR TITLE
Production preparations for VD

### DIFF
--- a/dunereco/DUNEPandora/pandoramodules_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodules_dune.fcl
@@ -41,6 +41,8 @@ dunefd_pandora_cosmic.ShouldRunCosmicRecoOption:                    true
 dunefdvd_pandora_neutrino:                                          @local::dune_pandora
 dunefdvd_pandora_neutrino.ConfigFile:                               "PandoraSettings_Master_DUNEFD_VD.xml"
 dunefdvd_pandora_neutrino.ShouldRunNeutrinoRecoOption:              true
+dunefdvd_pandora_neutrino.EnableMCParticles:                        true
+dunefdvd_pandora_neutrino.SimChannelModuleLabel:                    "tpcrawdecoder:simpleSC"
 dunefdvd_pandora_neutrino.HitFinderModuleLabel:                     "gaushit"
 
 dunefdvd_pandora_cosmic:                                            @local::dunefdvd_pandora_neutrino

--- a/dunereco/FDSensOpt/energyreco.fcl
+++ b/dunereco/FDSensOpt/energyreco.fcl
@@ -52,12 +52,15 @@ dunefd_nuenergyreco_pandora_nc:
 
 dunefdvd_nuenergyreco_pandora_numu: @local::dunefd_nuenergyreco_pandora_numu
 dunefdvd_nuenergyreco_pandora_numu.NeutrinoEnergyRecoAlg: @local::dunevd10kt_neutrinoenergyrecoalg
+dunefdvd_nuenergyreco_pandora_numu.WireLabel: "tpcrawdecoder:gauss"
 
 dunefdvd_nuenergyreco_pandora_nue:  @local::dunefd_nuenergyreco_pandora_nue
 dunefdvd_nuenergyreco_pandora_nue.NeutrinoEnergyRecoAlg: @local::dunevd10kt_neutrinoenergyrecoalg
+dunefdvd_nuenergyreco_pandora_nue.WireLabel:  "tpcrawdecoder:gauss"
 
 dunefdvd_nuenergyreco_pandora_nc:   @local::dunefd_nuenergyreco_pandora_nc
 dunefdvd_nuenergyreco_pandora_nc.NeutrinoEnergyRecoAlg: @local::dunevd10kt_neutrinoenergyrecoalg
+dunefdvd_nuenergyreco_pandora_nc.WireLabel:  "tpcrawdecoder:gauss"
 
 
 END_PROLOG

--- a/dunereco/HitFinderDUNE/hitfindermodules_dune.fcl
+++ b/dunereco/HitFinderDUNE/hitfindermodules_dune.fcl
@@ -194,9 +194,9 @@ dunefd_hitfinderfd.DisambigAlg.DistanceCutClu: 100
 
 # gauss hit finder for VD module
 dunevdfd_gaushitfinder: @local::gaus_hitfinder
-dunevdfd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold: 0.6
-dunevdfd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold: 0.6
-dunevdfd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold: 0.6
+dunevdfd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold: 2.0 
+dunevdfd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold: 2.0 
+dunevdfd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold: 2.0 
 dunevdfd_gaushitfinder.InitWidth: [6.0, 6.0, 6.0]
 dunevdfd_gaushitfinder.AreaNorms: [13.25, 13.25, 13.25]
 dunevdfd_gaushitfinder.MaxMultiHit: 4

--- a/dunereco/HitFinderDUNE/hitfindermodules_dune.fcl
+++ b/dunereco/HitFinderDUNE/hitfindermodules_dune.fcl
@@ -204,7 +204,7 @@ dunevdfd_gaushitfinder.Chi2NDF: 50
 dunevdfd_gaushitfinder.LongMaxHits: [ 25, 25, 25 ]
 dunevdfd_gaushitfinder.LongPulseWidth: [ 10, 10, 10 ]
 dunevdfd_gaushitfinder.PeakFitter:	@local::peakfitter_mrqdt
-dunevdfd_gaushitfinder.CalDataModuleLabel: "wclsdatanfsp:gauss"
+dunevdfd_gaushitfinder.CalDataModuleLabel: "tpcrawdecoder:gauss"
 
 protodunespmc_gaushitfinder: @local::gaus_hitfinder
 protodunespmc_gaushitfinder.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold: 0.6


### PR DESCRIPTION
To be merged with https://github.com/DUNE/dunesw/pull/16
 
 - Some example MC showed too much noise in the EVDs.  Increasing the threshold using values suggested by Slavic has squashed the noise down.
 - Enable passing through MC in pandora, to create the validation files by default.
 - Update the default wire module labels as the signal sim and sig proc workflows have been merged into one.
 