### PR TITLE
Check invalid points when calculating MCS momentum

### DIFF
--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.cc
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.cc
@@ -297,7 +297,7 @@ double NeutrinoEnergyRecoAlg::CalculateLinearlyCorrectedValue(const double value
 double NeutrinoEnergyRecoAlg::CalculateUncorrectedMuonMomentumByMCS(const art::Ptr<recob::Track> &pMuonTrack)
 {
     trkf::TrackMomentumCalculator TrackMomCalc;
-    return (TrackMomCalc.GetMomentumMultiScatterChi2(pMuonTrack));
+    return (TrackMomCalc.GetMomentumMultiScatterChi2(pMuonTrack, true));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
We added a function in larreco/RecoAlg/TrackMomentrumCalculator.cxx to check whether the point is valid, which has been an issue for pandoraTrack when calculating MCS momentum. By switching the flag on, it will get rid of the invalid points from pandoraTrack and return sensible MCS momentum.

**NB: This cannot be merged until the [larreco PR](https://github.com/LArSoft/larreco/pull/43) is merged and in a larsoft release.**