### PR TITLE
Add specific ProtoDUNE-HD Pandora config using cuts for beam id

### DIFF
--- a/dunereco/DUNEPandora/pandoramodules_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodules_dune.fcl
@@ -59,6 +59,10 @@ protodune_pandora.ShouldRunNeutrinoRecoOption:                      true
 protodune_pandora.ShouldRunCosmicRecoOption:                        true
 protodune_pandora.ShouldPerformSliceId:                             true
 
+#----ProtoDUNE HD----
+protodunehd_pandora:                                                @local::protodune_pandora
+protodunehd_pandora.ConfigFile:                                     "PandoraSettings_Master_ProtoDUNE_HD.xml"
+
 #----ProtoDUNE DP----
 protodune_dp_pandora:                                               @local::dune_pandora
 protodune_dp_pandora.ConfigFile:                                    "PandoraSettings_Master_ProtoDUNE_DP.xml"

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD.xml
@@ -1,0 +1,56 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArPreProcessing">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+    <algorithm type = "LArVisualMonitoring">
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</CaloHitListNames>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+
+    <algorithm type = "LArMaster">
+        <CRSettingsFile>PandoraSettings_Cosmic_ProtoDUNE.xml</CRSettingsFile>
+        <NuSettingsFile>PandoraSettings_TestBeam_ProtoDUNE.xml</NuSettingsFile>
+        <SlicingSettingsFile>PandoraSettings_Slicing_ProtoDUNE.xml</SlicingSettingsFile>
+        <StitchingTools>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>false</ThreeDStitchingMode></tool>
+        </StitchingTools>
+        <CosmicRayTaggingTools>
+            <tool type = "LArCosmicRayTagging"/>
+        </CosmicRayTaggingTools>
+        <SliceIdTools>
+<!--
+            <tool type = "LArBdtBeamParticleId">
+                <BdtName>ProtoDUNESP_BeamParticleId</BdtName>
+                <BdtFileName>PandoraMVAData/PandoraBdt_BeamParticleId_ProtoDUNESP_v03_26_00.xml</BdtFileName>
+                <MinAdaBDTScore>-0.225</MinAdaBDTScore>
+            </tool>
+-->
+        <!-- Fall back to the old cuts method for now -->
+            <tool type = "LArBeamParticleId">
+                <BeamTPCIntersection>-66.06 400.3 0.0</BeamTPCIntersection>
+                <BeamDirection>-0.201890 -0.192850 0.960234</BeamDirection> 
+            </tool>
+        </SliceIdTools>
+        <InputHitListName>CaloHitList2D</InputHitListName>
+        <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
+        <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
+        <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
+        <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
+    </algorithm>
+
+    <algorithm type = "LArVisualMonitoring">
+        <ShowCurrentPfos>true</ShowCurrentPfos>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+</pandora>


### PR DESCRIPTION
Added a new Pandora settings file for ProtoDUNE-HD. It is identical to the ProtoDUNE-SP one but swaps out the BDT-based beam id for the original cuts based one, but with parameters specific for ProtoDUNE-HD. Added `protodunehd_pandora` for use in configuration files in place of `protodune_pandora` for ProtoDUNE-HD.