### PR TITLE
Feature/pandora track and shower module run on all pf ps

### DIFF
--- a/dunereco/DUNEPandora/pandoramodularshowertools_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodularshowertools_dune.fcl
@@ -47,7 +47,10 @@ dune_showerunidirectiondedx.CalorimetryAlg:                          @local::dun
 dune_showerunidirectiondedx.InitialTrackHitsInputLabel:              "InitialTrackHits3DCylinder"
 dune_showerunidirectiondedx.dEdxTrackLength:                         5.7
 
-dunefdvd_showerunidirectiondedx: @local::dune_showerunidirectiondedx
+dunefdhd_showerunidirectiondedx: @local::dune_showerunidirectiondedx
+dunefdhd_showerunidirectiondedx.CalorimetryAlg: @local::dune10kt_calorimetryalgmc
+
+dunefdvd_showerunidirectiondedx: @local::dunefdhd_showerunidirectiondedx
 dunefdvd_showerunidirectiondedx.CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
 
 dune_showertrajpointdedx:                                            @local::showertrajpointdedx
@@ -58,14 +61,20 @@ dune_showertrajpointdedx.MinAngleToWire:                             0.0
 dune_showertrajpointdedx.dEdxTrackLength:                            4.6
 dune_showertrajpointdedx.dEdxCut:                                    999.0
 
-dunefdvd_showertrajpointdedx: @local::dune_showertrajpointdedx
+dunefdhd_showertrajpointdedx: @local::dune_showertrajpointdedx
+dunefdhd_showertrajpointdedx.CalorimetryAlg: @local::dune10kt_calorimetryalgmc
+
+dunefdvd_showertrajpointdedx: @local::dunefdhd_showertrajpointdedx
 dunefdvd_showertrajpointdedx.CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
 
 #Shower energy tools
 dune_showernumelectronsenergy:                                       @local::showernumelectronsenergy
 dune_showernumelectronsenergy.CalorimetryAlg:                        @local::dune10kt_calorimetryalgmc
 
-dunefdvd_showernumelectronsenergy: @local::dune_showernumelectronsenergy
+dunefdhd_showernumelectronsenergy: @local::dune_showernumelectronsenergy
+dunefdhd_showernumelectronsenergy.CalorimetryAlg: @local::dune10kt_calorimetryalgmc
+
+dunefdvd_showernumelectronsenergy: @local::dunefdhd_showernumelectronsenergy
 dunefdvd_showernumelectronsenergy.CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
 
 END_PROLOG

--- a/dunereco/DUNEPandora/pandoramodules_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodules_dune.fcl
@@ -104,8 +104,19 @@ dune_pandoraModularShowerCreation.ShowerFinderTools: [
   @local::dune_showertrajpointdedx
 ]
 
-dunefdhd_pandoraModularShowerCreation: @local::pandoraModularShowerCreation
+dunefdhd_pandoraModularShowerCreation: @local::dune_pandoraModularShowerCreation
 dunefdhd_pandoraModularShowerCreation.UseAllParticles:                      true
+dunefdhd_pandoraModularShowerCreation.ShowerFinderTools: [
+  @local::dune_showerpfpvertexstartposition,
+  @local::dune_showerpcadirection,
+  @local::dune_showerlengthpercentile,
+  @local::dunefdhd_showernumelectronsenergy,
+  @local::dune_3dcylindertrackhitfinder,
+  @local::dunefdhd_showerunidirectiondedx,
+  @local::dune_showerincrementaltrackhitfinder,
+  @local::dune_showerpandoraslidingfittrackfinder,
+  @local::dunefdhd_showertrajpointdedx
+]
 
 dunefdvd_pandoraModularShowerCreation: @local::dunefdhd_pandoraModularShowerCreation
 dunefdvd_pandoraModularShowerCreation.ShowerFinderTools: [
@@ -126,7 +137,7 @@ dune_pandoraShowerCreation:
     module_type:                                                    "LArPandoraShowerCreation"
 }
 
-dunefdhd_pandoraShowerCreation: @local::pandoraShowerCreation
+dunefdhd_pandoraShowerCreation: @local::dune_pandoraShowerCreation
 dunefdhd_pandoraShowerCreation.UseAllParticles:                      true
 
 dunefdvd_pandoraShowerCreation: @local::dunefdhd_pandoraShowerCreation 

--- a/dunereco/DUNEPandora/pandoramodules_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodules_dune.fcl
@@ -85,7 +85,10 @@ dune_pandoraTrackCreation:
     PFParticleLabel:                                                "pandora"
 }
 
-dunefdvd_pandoraTrackCreation: @local::dune_pandoraTrackCreation 
+dunefdhd_pandoraTrackCreation: @local::dune_pandoraTrackCreation
+dunefdhd_pandoraTrackCreation.UseAllParticles:                      true
+
+dunefdvd_pandoraTrackCreation: @local::dunefdhd_pandoraTrackCreation 
 
 dune_pandoraModularShowerCreation:                                         @local::standard_pandoraModularShowerCreation
 dune_pandoraModularShowerCreation.PFParticleLabel:                  "pandora"
@@ -101,7 +104,10 @@ dune_pandoraModularShowerCreation.ShowerFinderTools: [
   @local::dune_showertrajpointdedx
 ]
 
-dunefdvd_pandoraModularShowerCreation: @local::dune_pandoraModularShowerCreation
+dunefdhd_pandoraModularShowerCreation: @local::pandoraModularShowerCreation
+dunefdhd_pandoraModularShowerCreation.UseAllParticles:                      true
+
+dunefdvd_pandoraModularShowerCreation: @local::dunefdhd_pandoraModularShowerCreation
 dunefdvd_pandoraModularShowerCreation.ShowerFinderTools: [
   @local::dune_showerpfpvertexstartposition,
   @local::dune_showerpcadirection,
@@ -119,6 +125,12 @@ dune_pandoraShowerCreation:
 {
     module_type:                                                    "LArPandoraShowerCreation"
 }
+
+dunefdhd_pandoraShowerCreation: @local::pandoraShowerCreation
+dunefdhd_pandoraShowerCreation.UseAllParticles:                      true
+
+dunefdvd_pandoraShowerCreation: @local::dunefdhd_pandoraShowerCreation 
+
 
 dunefd_pandora:                                                      @local::dunefd_pandora_neutrino
 

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_Atmos_DUNEFD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_Atmos_DUNEFD.xml
@@ -503,6 +503,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>
@@ -615,6 +616,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD.xml
@@ -502,6 +502,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>
@@ -614,6 +615,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD_VD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD_VD.xml
@@ -491,6 +491,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>
@@ -603,6 +604,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Streaming_Neutrino_DUNEFD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Streaming_Neutrino_DUNEFD.xml
@@ -501,6 +501,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>
@@ -599,6 +600,7 @@
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <PersistFeatures>true</PersistFeatures>
         <FeatureTools>
             <tool type = "LArThreeDLinearFitFeatureTool"/>
             <tool type = "LArThreeDVertexDistanceFeatureTool"/>


### PR DESCRIPTION
(Please do not merge this PR yet - further tests are ongoing)

This PR makes changes to pandoraTrackCreation and pandoraShowerCreation settings so that these modules run on all PFPs. This change, discussed within FD sim/reco and analysis working groups, will enable analysers to decide what particles are track-like and what particles are shower-like by placing their own cuts on the Pandora track/shower score, instead of only reading objects that are labelled as track or as shower by Pandora.
This will potentially yield gains in efficiency, as we found evidence for in [low energy samples](https://indico.fnal.gov/event/58867/contributions/262071/attachments/164742/218565/March%202023%20FD%20Sim_Reco%20Talk.pdf).

Corresponding changes to Pandora's XML settings files have been made to enable the track/shower score to be persisted.

