### PR TITLE
Disable saving both outcomes for the FD workflows

### DIFF
--- a/dunereco/DUNEPandora/pandoramodules_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodules_dune.fcl
@@ -86,7 +86,7 @@ dune_pandoraTrackCreation:
 }
 
 dunefdhd_pandoraTrackCreation: @local::dune_pandoraTrackCreation
-dunefdhd_pandoraTrackCreation.UseAllParticles:                      true
+dunefdhd_pandoraTrackCreation.UseAllParticles:                      false
 
 dunefdvd_pandoraTrackCreation: @local::dunefdhd_pandoraTrackCreation 
 
@@ -105,7 +105,7 @@ dune_pandoraModularShowerCreation.ShowerFinderTools: [
 ]
 
 dunefdhd_pandoraModularShowerCreation: @local::dune_pandoraModularShowerCreation
-dunefdhd_pandoraModularShowerCreation.UseAllParticles:                      true
+dunefdhd_pandoraModularShowerCreation.UseAllParticles:                      false
 dunefdhd_pandoraModularShowerCreation.ShowerFinderTools: [
   @local::dune_showerpfpvertexstartposition,
   @local::dune_showerpcadirection,
@@ -138,7 +138,7 @@ dune_pandoraShowerCreation:
 }
 
 dunefdhd_pandoraShowerCreation: @local::dune_pandoraShowerCreation
-dunefdhd_pandoraShowerCreation.UseAllParticles:                      true
+dunefdhd_pandoraShowerCreation.UseAllParticles:                      false
 
 dunefdvd_pandoraShowerCreation: @local::dunefdhd_pandoraShowerCreation 
 


### PR DESCRIPTION
Reverts some of the PR #40 merge.
The code will now not save both track/shower outcomes.  We will re-enable this soon.