### PR TITLE
Use correct upstream simulation params in FD1/FD2 wirecell configs

### DIFF
--- a/dunereco/DUNEWireCell/wirecell_dune.fcl
+++ b/dunereco/DUNEWireCell/wirecell_dune.fcl
@@ -413,16 +413,19 @@ tpcrawdecoder_dunefd_horizdrift_1x2x6 : {
       params: {
       }
       structs: {
-        # Longitudinal diffusion constant [cm2/s]
-        DL: 4.0
-        # Transverse diffusion constant [cm2/s]
-        DT: 8.8
-        # Electron lifetime [ms]
-        lifetime: 10
-        # Electron drift speed, assumes a certain applied E-field [mm/us]
-        driftSpeed: 1.60563
-        # G4RefTime [us]
-        G4RefTime: @local::dunefd_detectorclocks.G4RefTime
+          # number of time samples
+          #nticks: @local::dunefd_detproperties.NumberTimeSamples
+          # Longitudinal diffusion constant [cm2/ns]
+          DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+          # Transverse diffusion constant [cm2/ns]
+          DT: @local::dunefd_largeantparameters.TransverseDiffusion
+          # Electron lifetime [us]
+          lifetime: @local::dunefd_detproperties.Electronlifetime
+          # Electron drift speed, assumes a certain applied E-field [mm/us]
+          driftSpeed: 1.60563
+          # G4RefTime [us]
+          G4RefTime: @local::dunefd_detectorclocks.G4RefTime
+
       }
 
    }
@@ -449,16 +452,20 @@ dunefd_horizdrift_1x2x6_sim_nfsp : {
         params: {
         }
         structs: {
-          # Longitudinal diffusion constant [cm2/s]
-          DL: 4.0
-          # Transverse diffusion constant [cm2/s]
-          DT: 8.8
-          # Electron lifetime [ms]
-          lifetime: 10
+          # number of time samples
+          #nticks: @local::dunefd_detproperties.NumberTimeSamples
+          # Longitudinal diffusion constant [cm2/ns]
+          DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+          # Transverse diffusion constant [cm2/ns]
+          DT: @local::dunefd_largeantparameters.TransverseDiffusion
+          # Electron lifetime [us]
+          lifetime: @local::dunefd_detproperties.Electronlifetime
           # Electron drift speed, assumes a certain applied E-field [mm/us]
           driftSpeed: 1.60563
           # G4RefTime [us]
           G4RefTime: @local::dunefd_detectorclocks.G4RefTime
+
+
         }
     }
 }

--- a/dunereco/DUNEWireCell/wirecell_dune.fcl
+++ b/dunereco/DUNEWireCell/wirecell_dune.fcl
@@ -567,9 +567,9 @@ tpcrawdecoder_dunefd_vertdrift_2view : {
         # number of time samples
         nticks: @local::dunefdvd_detproperties.NumberTimeSamples
         # Longitudinal diffusion constant [cm2/ns] 4.0e-9
-        DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+        DL: @local::dunefdvd_largeantparameters.LongitudinalDiffusion
         # Transverse diffusion constant [cm2/ns] 8.8e-9
-        DT: @local::dunefd_largeantparameters.TransverseDiffusion
+        DT: @local::dunefdvd_largeantparameters.TransverseDiffusion
         # Electron lifetime [us] #10.4e3
         lifetime: @local::dunefdvd_detproperties.Electronlifetime
         # Electron drift speed, assumes a certain applied E-field [mm/us]
@@ -599,9 +599,9 @@ tpcrawdecoder_dunefd_vertdrift_3view: {
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
-          DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+          DL: @local::dunefdvd_largeantparameters.LongitudinalDiffusion
           # Transverse diffusion constant [cm2/ns] 8.8e-9
-          DT: @local::dunefd_largeantparameters.TransverseDiffusion
+          DT: @local::dunefdvd_largeantparameters.TransverseDiffusion
           # Electron lifetime [us] #10.4e3
           lifetime: @local::dunefdvd_detproperties.Electronlifetime
           # Electron drift speed, assumes a certain applied E-field [mm/us]
@@ -629,9 +629,9 @@ tpcrawdecoder_dunefd_vertdrift_1x8x6_3view: {
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
-          DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+          DL: @local::dunefdvd_largeantparameters.LongitudinalDiffusion
           # Transverse diffusion constant [cm2/ns] 8.8e-9
-          DT: @local::dunefd_largeantparameters.TransverseDiffusion
+          DT: @local::dunefdvd_largeantparameters.TransverseDiffusion
           # Electron lifetime [us] #10.4e3
           lifetime: @local::dunefdvd_detproperties.Electronlifetime
           # Electron drift speed, assumes a certain applied E-field [mm/us]
@@ -659,9 +659,9 @@ tpcrawdecoder_dunefd_vertdrift_1x8x14_3view: {
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
-          DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+          DL: @local::dunefdvd_largeantparameters.LongitudinalDiffusion
           # Transverse diffusion constant [cm2/ns] 8.8e-9
-          DT: @local::dunefd_largeantparameters.TransverseDiffusion
+          DT: @local::dunefdvd_largeantparameters.TransverseDiffusion
           # Electron lifetime [us] #10.4e3
           lifetime: @local::dunefdvd_detproperties.Electronlifetime
           # Electron drift speed, assumes a certain applied E-field [mm/us]
@@ -690,9 +690,9 @@ tpcrawdecoder_dunefd_vertdrift_3view_30deg: {
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
-          DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+          DL: @local::dunefdvd_largeantparameters.LongitudinalDiffusion
           # Transverse diffusion constant [cm2/ns] 8.8e-9
-          DT: @local::dunefd_largeantparameters.TransverseDiffusion
+          DT: @local::dunefdvd_largeantparameters.TransverseDiffusion
           # Electron lifetime [us] #10.4e3
           lifetime: @local::dunefdvd_detproperties.Electronlifetime
           # Electron drift speed, assumes a certain applied E-field [mm/us]
@@ -720,9 +720,9 @@ tpcrawdecoder_dunefd_vertdrift_1x8x6_3view_30deg: {
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
-          DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+          DL: @local::dunefdvd_largeantparameters.LongitudinalDiffusion
           # Transverse diffusion constant [cm2/ns] 8.8e-9
-          DT: @local::dunefd_largeantparameters.TransverseDiffusion
+          DT: @local::dunefdvd_largeantparameters.TransverseDiffusion
           # Electron lifetime [us] #10.4e3
           lifetime: @local::dunefdvd_detproperties.Electronlifetime
           # Electron drift speed, assumes a certain applied E-field [mm/us]


### PR DESCRIPTION
This can be merged immediately.