### PR TITLE
Use larsoft units in one FD-HD jsonnet

### DIFF
--- a/dunereco/DUNEWireCell/dune10kt-1x2x6/wcls-sim-drift-simchannel-nf-sp.jsonnet
+++ b/dunereco/DUNEWireCell/dune10kt-1x2x6/wcls-sim-drift-simchannel-nf-sp.jsonnet
@@ -19,11 +19,11 @@ local fcl_params = {
 local params = params_maker(fcl_params) {
   lar: super.lar {
     // Longitudinal diffusion constant
-    DL: std.extVar('DL') * wc.cm2 / wc.s,
+    DL: std.extVar('DL') * wc.cm2 / wc.ns,
     // Transverse diffusion constant
-    DT: std.extVar('DT') * wc.cm2 / wc.s,
+    DT: std.extVar('DT') * wc.cm2 / wc.ns,
     // Electron lifetime
-    lifetime: std.extVar('lifetime') * wc.ms,
+    lifetime: std.extVar('lifetime') * wc.us,
     // Electron drift speed, assumes a certain applied E-field
     drift_speed: std.extVar('driftSpeed') * wc.mm / wc.us,
   },

--- a/dunereco/DUNEWireCell/dune10kt-1x2x6/wcls-sim-drift-simchannel.jsonnet
+++ b/dunereco/DUNEWireCell/dune10kt-1x2x6/wcls-sim-drift-simchannel.jsonnet
@@ -19,11 +19,11 @@ local fcl_params = {
 local params = params_maker(fcl_params) {
   lar: super.lar {
     // Longitudinal diffusion constant
-    DL: std.extVar('DL') * wc.cm2 / wc.s,
+    DL: std.extVar('DL') * wc.cm2 / wc.ns,
     // Transverse diffusion constant
-    DT: std.extVar('DT') * wc.cm2 / wc.s,
+    DT: std.extVar('DT') * wc.cm2 / wc.ns,
     // Electron lifetime
-    lifetime: std.extVar('lifetime') * wc.ms,
+    lifetime: std.extVar('lifetime') * wc.us,
     // Electron drift speed, assumes a certain applied E-field
     drift_speed: std.extVar('driftSpeed') * wc.mm / wc.us,
   },


### PR DESCRIPTION
These changes needs #50 to be consistent
**Please note: this is not a sweeping change for all HD jsonnet cfg. Just these below related to official larsoft integration:**
 - wcls-sim-drift-simchannel.jsonnet
 - wcls-sim-drift-simchannel-nf-sp.jsonnet
