### PR TITLE
Update energy reco parameter set names in fcls

### DIFF
--- a/dunereco/CVN/fcl/dune_cvn_event_dump_fhc.fcl
+++ b/dunereco/CVN/fcl/dune_cvn_event_dump_fhc.fcl
@@ -33,8 +33,8 @@ physics:
   # Declare the modules
   producers:
   { 
-    energynue:  @local::dunefd_nuenergyreco
-    energynumu: @local::dunefd_nuenergyreco
+    energynue:  @local::dunefd_nuenergyreco_pmtrack
+    energynumu: @local::dunefd_nuenergyreco_pmtrack
     cvnmap:     @local::standard_cvnmapper
   }
 

--- a/dunereco/CVN/fcl/dune_cvn_event_dump_rhc.fcl
+++ b/dunereco/CVN/fcl/dune_cvn_event_dump_rhc.fcl
@@ -33,8 +33,8 @@ physics:
   # Declare the modules
   producers:
   { 
-    energynue:  @local::dunefd_nuenergyreco
-    energynumu: @local::dunefd_nuenergyreco
+    energynue:  @local::dunefd_nuenergyreco_pmtrack
+    energynumu: @local::dunefd_nuenergyreco_pmtrack
     cvnmap:     @local::standard_cvnmapper
   }
 

--- a/dunereco/CVN/fcl/dune_cvn_zlib_maker.fcl
+++ b/dunereco/CVN/fcl/dune_cvn_zlib_maker.fcl
@@ -28,9 +28,9 @@ physics:
 {
   producers:
   {
-    energynue:   @local::dunefd_nuenergyreco
-    energynumu:  @local::dunefd_nuenergyreco
-    energynutau: @local::dunefd_nuenergyreco
+    energynue:   @local::dunefd_nuenergyreco_pmtrack
+    energynumu:  @local::dunefd_nuenergyreco_pmtrack
+    energynutau: @local::dunefd_nuenergyreco_pmtrack
     cvnmap:      @local::standard_cvnmapper
   }
   analyzers:

--- a/dunereco/RegCNN/macro/regcnn_numu_ana_job.fcl
+++ b/dunereco/RegCNN/macro/regcnn_numu_ana_job.fcl
@@ -25,7 +25,7 @@ physics:
   producers:
   {
     mvaselectnumu:    @local::dunefd_mvaselect
-    energyreconumu:   @local::dunefd_nuenergyreco
+    energyreconumu:   @local::dunefd_nuenergyreco_pmtrack
   }
   analyzers:   
   {

--- a/dunereco/RegCNN/macro/regcnnanajob.fcl
+++ b/dunereco/RegCNN/macro/regcnnanajob.fcl
@@ -25,7 +25,7 @@ physics:
   producers:
   {
     mvaselectnue:   @local::dunefd_mvaselect
-    energyreconue:  @local::dunefd_nuenergyreco
+    energyreconue:  @local::dunefd_nuenergyreco_pmtrack
   }
   analyzers:   
   {

--- a/dunereco/VLNets/art/data_generators/vlnenergydatagenjob.fcl
+++ b/dunereco/VLNets/art/data_generators/vlnenergydatagenjob.fcl
@@ -21,7 +21,7 @@ source:
 
 physics:
 {
-    producers: { energyreconumu: @local::dunefd_nuenergyreco }
+    producers: { energyreconumu: @local::dunefd_nuenergyreco_pmtrack }
     analyzers: { vlnenergydatagen: @local::dunefd_vlnenergydatagen_numu }
 
     ana:  [ vlnenergydatagen ]


### PR DESCRIPTION
Some neglected fcls did not get the memo when energyreco.fcl got refactored