### PR TITLE
fix to spacepoint disambiguator module

### DIFF
--- a/dunereco/HitFinderDUNE/DisambigFromSpacePoints_module.cc
+++ b/dunereco/HitFinderDUNE/DisambigFromSpacePoints_module.cc
@@ -325,7 +325,9 @@ namespace dune {
                     {
                         if (cwids[w].TPC != spTpc) { continue; } // not that side of APA
 
-                        float sp_wire = fGeom->WireCoordinate(sp->position(), id);
+                        float sp_wire = fGeom->WireCoordinate(
+                            sp->position(), geo::PlaneID(cryo, spTpc, plane)
+                        );
                         float dw = std::fabs(sp_wire - cwids[w].Wire);
                         if (dw < max_dw)
                         {


### PR DESCRIPTION
This has been broken for year when the geometry API changed. The WireCoordinate function was using the same PlaneID object for each space point when it should be using the PlaneID object that is facing the same tpc the space point is in. 

This was causing spacepoint to solver to fail disambiguation quite frequently, with this fix it is more reasonable and aligns very closely with the timing based disambig.