### PR TITLE
Fixed momentum reconstruction based on range

### DIFF
--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.cc
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.cc
@@ -235,7 +235,8 @@ NeutrinoEnergyRecoAlg::Momentum4_t NeutrinoEnergyRecoAlg::CalculateParticle4Mome
 
 double NeutrinoEnergyRecoAlg::CalculateMuonMomentumByRange(const art::Ptr<recob::Track> pMuonTrack)
 {
-    return this->CalculateLinearlyCorrectedValue(pMuonTrack->Length(), fGradTrkMomRange, fIntTrkMomRange);
+    const double uncorrectedMomentum(this->CalculateUncorrectedMuonMomentumByRange(pMuonTrack));
+    return this->CalculateLinearlyCorrectedValue(uncorrectedMomentum, fGradTrkMomRange, fIntTrkMomRange);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -290,6 +291,14 @@ double NeutrinoEnergyRecoAlg::CalculateLinearlyCorrectedValue(const double value
     const double correctionIntercept)
 {
     return (value - correctionIntercept) / correctionGradient;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+double NeutrinoEnergyRecoAlg::CalculateUncorrectedMuonMomentumByRange(const art::Ptr<recob::Track> &pMuonTrack)
+{
+    trkf::TrackMomentumCalculator TrackMomCalc;
+    return (TrackMomCalc.GetTrackMomentum(pMuonTrack->Length(), 13));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.h
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.h
@@ -237,6 +237,15 @@ class NeutrinoEnergyRecoAlg
             const double correctionIntercept);
 
         /**
+        * @brief  Calculates the raw muon momentum by continuous-slowing-down approximation (CSDA) table
+        *
+        * @param  trkrange the muon track range (in cm)
+        *
+        * @return the uncorrected reconstructed muon momentum (in GeV)
+        */
+        double CalculateUncorrectedMuonMomentumByRange(const art::Ptr<recob::Track> &pMuonTrack);
+
+        /**
         * @brief  Calculates the raw muon momentum by multiple coulomb scattering
         *
         * @param  pMuonTrack the muon track


### PR DESCRIPTION
Previous version was using the muon length instead. 
