### PR TITLE
Reducing the size of output files, and fixing a bug

### DIFF
--- a/dunereco/FDSelections/CCNuSelection.fcl
+++ b/dunereco/FDSelections/CCNuSelection.fcl
@@ -1,4 +1,3 @@
-
 #include "calorimetry_dune10kt.fcl"
 #include "showeralgorithms.fcl"
 #include "ctphelper.fcl"
@@ -27,29 +26,52 @@ CCNuSelection:
    NumuEnergyRecoModuleLabel:   "energyreconumu"
    NueEnergyRecoModuleLabel:    "energyreconue"
  }                                
- PandizzleWeightFileName:  "Pandizzle_TMVAClassification_BDTG.weights.xml"
- PandrizzleWeightFileName: "Pandrizzle_TMVAClassification_BDTG.weights.xml"
 
-   CVNModuleLabel: "cvnevalSel"
+ MakeSelectionTrainingTrees:              true
+ PandizzleWeightFileName:                "MCC11_FHC_Pandizzle_TMVAClassification_BDTG_standard.weights.xml"
+ PandrizzleWeightFileName:               "MCC11_FHC_Pandrizzle_TMVAClassification_BDTG_standard.weights.xml"
+ EnhancedPandrizzleWeightFileName:       ""
+ UseConcentration:                       true
+ UseDisplacement:                        true
+ UseDCA:                                 true
+ UseBDTVariables:                        false
+ UseModularShowerVariables:              false
+ EnhancedPandrizzleHitCut:               100
+ BackupPandrizzleHitCut:                 25
+
+ CVNModuleLabel: "cvnevalSel"
 
  CalorimetryAlg:              @local::dune10kt_calorimetryalgmc
  ShowerEnergyAlg:             @local::dune10kt_showerenergy
  ctpHelper:                   @local::standard_ctphelper
+
  NeutrinoEnergyRecoAlg:       @local::dune10kt_neutrinoenergyrecoalg
  UsePandoraVertex: true
 
  MichelCandidateDistance: 4
-
 }
-CCNuSelection.RecoTrackSelectorTool.tool_type: "LongestRecoVertexTrackSelector"
-CCNuSelection.RecoTrackSelectorTool.ctpHelper: @local::CCNuSelection.ctpHelper
-CCNuSelection.RecoTrackSelectorTool.ModuleLabels: @local::CCNuSelection.ModuleLabels
 
-CCNuSelection.RecoShowerSelectorTool.tool_type: "HighestEnergyRecoVertexShowerSelector"
-CCNuSelection.RecoShowerSelectorTool.ModuleLabels: @local::CCNuSelection.ModuleLabels
-CCNuSelection.RecoShowerSelectorTool.ShowerEnergyAlg: @local::CCNuSelection.ShowerEnergyAlg
+# Pandizzle track selector tool
+CCNuSelection.RecoTrackSelectorTool.tool_type:                                 "HighestPandizzleScoreRecoVertexTrackSelector"
+CCNuSelection.RecoTrackSelectorTool.PandizzleWeightFileName:                   "MCC11_FHC_Pandizzle_TMVAClassification_BDTG_standard.weights.xml"
+CCNuSelection.RecoTrackSelectorTool.MichelCandidateDistance:                    4
+CCNuSelection.RecoTrackSelectorTool.ShowerEnergyAlg:                            @local::CCNuSelection.ShowerEnergyAlg
+CCNuSelection.RecoTrackSelectorTool.ModuleLabels:                               @local::CCNuSelection.ModuleLabels
+CCNuSelection.RecoTrackSelectorTool.MakeSelectionTrainingTrees:                 false
 
-#CCNuSelection.ctpHelper.NetworkName: "convolutional_track_pid_April2020_new.pb"
-
+# Pandrizzle shower selector tool
+CCNuSelection.RecoShowerSelectorTool.tool_type:                                "HighestPandrizzleScoreRecoVertexShowerSelector"
+CCNuSelection.RecoShowerSelectorTool.EnhancedPandrizzleWeightFileName:         ""
+CCNuSelection.RecoShowerSelectorTool.PandrizzleWeightFileName:                 "MCC11_FHC_Pandrizzle_TMVAClassification_BDTG_standard.weights.xml"
+CCNuSelection.RecoShowerSelectorTool.ModuleLabels:                              @local::CCNuSelection.ModuleLabels
+CCNuSelection.RecoShowerSelectorTool.ShowerEnergyAlg:                           @local::CCNuSelection.ShowerEnergyAlg
+CCNuSelection.RecoShowerSelectorTool.MakeSelectionTrainingTrees:                false
+CCNuSelection.RecoShowerSelectorTool.BackupPandrizzleHitCut:                    25
+CCNuSelection.RecoShowerSelectorTool.EnhancedPandrizzleHitCut:                  100
+CCNuSelection.RecoShowerSelectorTool.UseBDTVariables:                           false
+CCNuSelection.RecoShowerSelectorTool.UseConcentration:                          true
+CCNuSelection.RecoShowerSelectorTool.UseDisplacement:                           true
+CCNuSelection.RecoShowerSelectorTool.UseDCA:                                    true
+CCNuSelection.RecoShowerSelectorTool.UseModularShowerVariables:                 false
 
 END_PROLOG

--- a/dunereco/FDSelections/pandizzle/PandizzleAlg.cxx
+++ b/dunereco/FDSelections/pandizzle/PandizzleAlg.cxx
@@ -53,6 +53,7 @@ FDSelection::PandizzleAlg::PandizzleAlg(const fhicl::ParameterSet& pset) :
   fClusterModuleLabel(pset.get<std::string>("ModuleLabels.ClusterModuleLabel")),
   fIPMichelCandidateDistance(pset.get<double>("MichelCandidateDistance")),
   fMakeSelectionTrainingTrees(pset.get<bool>("MakeSelectionTrainingTrees")),
+  fReducedTreeMode(pset.get<bool>("ReducedTreeMode", true)),
   fPandizzleWeightFileName(pset.get< std::string > ("PandizzleWeightFileName")),
   fPandizzleReader("", 0)
 {
@@ -93,35 +94,10 @@ void FDSelection::PandizzleAlg::InitialiseTrees() {
 
   for (TTree* tree : {fSignalTrackTree, fBackgroundTrackTree})
   {
-    BookTreeInt(tree, "Event");
-    BookTreeInt(tree, "Run");
-    BookTreeInt(tree, "SubRun");
-    BookTreeInt(tree, "PFPPDG");
-    BookTreeInt(tree, "PFPNHits");
-    BookTreeInt(tree, "PFPTruePDG");
-    BookTreeInt(tree, "PFPTrueMotherID");
-    BookTreeFloat(tree, "PFPTrueMomT");
-    BookTreeFloat(tree, "PFPTrueMomX");
-    BookTreeFloat(tree, "PFPTrueMomY");
-    BookTreeFloat(tree, "PFPTrueMomZ");
-    BookTreeBool(tree,"PFPTrueIsMichelDecay");
-    BookTreeInt(tree, "PFPNChildren");
-    BookTreeInt(tree, "PFPNShowerChildren");
-    BookTreeInt(tree, "PFPNTrackChildren");
-    BookTreeFloat(tree, "PFPMichelDist");
     BookTreeInt(tree, "PFPMichelNHits");
-    BookTreeInt(tree, "PFPMichelTrueID");
-    BookTreeInt(tree, "PFPMichelTrueMotherID");
-    BookTreeInt(tree, "PFPMichelTruePDG");
     BookTreeFloat(tree, "PFPMichelElectronMVA");
-    BookTreeFloat(tree, "PFPMichelRecoEnergyPlane0");
-    BookTreeFloat(tree, "PFPMichelRecoEnergyPlane1");
     BookTreeFloat(tree, "PFPMichelRecoEnergyPlane2");
-    BookTreeFloat(tree,"PFPTrackDeflecAngleMean");
-    BookTreeFloat(tree,"PFPTrackDeflecAngleVar");
     BookTreeFloat(tree,"PFPTrackDeflecAngleSD");
-    BookTreeInt(tree,"PFPTrackDeflecNAngles");
-    BookTreeBool(tree, "MVAVarsFilled");
     BookTreeFloat(tree,"PFPTrackEvalRatio");
     BookTreeFloat(tree,"PFPTrackConcentration");
     BookTreeFloat(tree,"PFPTrackCoreHaloRatio");
@@ -129,15 +105,44 @@ void FDSelection::PandizzleAlg::InitialiseTrees() {
     BookTreeFloat(tree,"PFPTrackdEdxStart");
     BookTreeFloat(tree,"PFPTrackdEdxEnd");
     BookTreeFloat(tree,"PFPTrackdEdxEndRatio");
-    BookTreeFloat(tree,"PFPTrackMuonMVA");
-    BookTreeFloat(tree,"PFPTrackProtonMVA");
-    BookTreeFloat(tree,"PFPTrackPionMVA");
-    BookTreeFloat(tree,"PFPTrackPhotonMVA");
-    BookTreeFloat(tree,"PFPTrackElectronMVA");
-    BookTreeFloat(tree,"PFPTrackLengthRatio");
     BookTreeFloat(tree,"PFPTrackLength");
-    BookTreeFloat(tree,"PFPTrackOtherLengths");
-    BookTreeInt(tree,"PFPTrackIsLongest");
+
+    if(!fReducedTreeMode)
+    {
+      BookTreeInt(tree, "Event");
+      BookTreeInt(tree, "Run");
+      BookTreeInt(tree, "SubRun");
+      BookTreeInt(tree, "PFPPDG");
+      BookTreeInt(tree, "PFPNHits");
+      BookTreeInt(tree, "PFPTruePDG");
+      BookTreeInt(tree, "PFPTrueMotherID");
+      BookTreeFloat(tree, "PFPTrueMomT");
+      BookTreeFloat(tree, "PFPTrueMomX");
+      BookTreeFloat(tree, "PFPTrueMomY");
+      BookTreeFloat(tree, "PFPTrueMomZ");
+      BookTreeBool(tree,"PFPTrueIsMichelDecay");
+      BookTreeInt(tree, "PFPNChildren");
+      BookTreeInt(tree, "PFPNShowerChildren");
+      BookTreeInt(tree, "PFPNTrackChildren");
+      BookTreeFloat(tree, "PFPMichelDist");
+      BookTreeInt(tree, "PFPMichelTrueID");
+      BookTreeInt(tree, "PFPMichelTrueMotherID");
+      BookTreeInt(tree, "PFPMichelTruePDG");
+      BookTreeFloat(tree, "PFPMichelRecoEnergyPlane0");
+      BookTreeFloat(tree, "PFPMichelRecoEnergyPlane1");
+      BookTreeFloat(tree,"PFPTrackDeflecAngleMean");
+      BookTreeFloat(tree,"PFPTrackDeflecAngleVar");
+      BookTreeInt(tree,"PFPTrackDeflecNAngles");
+      BookTreeBool(tree, "MVAVarsFilled");
+      BookTreeFloat(tree,"PFPTrackMuonMVA");
+      BookTreeFloat(tree,"PFPTrackProtonMVA");
+      BookTreeFloat(tree,"PFPTrackPionMVA");
+      BookTreeFloat(tree,"PFPTrackPhotonMVA");
+      BookTreeFloat(tree,"PFPTrackElectronMVA");
+      BookTreeFloat(tree,"PFPTrackLengthRatio");
+      BookTreeFloat(tree,"PFPTrackOtherLengths");
+      BookTreeInt(tree,"PFPTrackIsLongest");
+    }
   }
 }
 

--- a/dunereco/FDSelections/pandizzle/PandizzleAlg.h
+++ b/dunereco/FDSelections/pandizzle/PandizzleAlg.h
@@ -125,6 +125,7 @@ class FDSelection::PandizzleAlg {
 
   // tree
   bool fMakeSelectionTrainingTrees;
+  bool fReducedTreeMode;
   TTree* fSignalTrackTree;
   TTree *fBackgroundTrackTree;
 

--- a/dunereco/FDSelections/pandoranuselection.fcl
+++ b/dunereco/FDSelections/pandoranuselection.fcl
@@ -19,7 +19,7 @@ pandoranuselection:
     SpacePointModuleLabel:                 "pandoraSel"
   }
 
-  MakeSelectionTrainingTrees:              true
+  MakeSelectionTrainingTrees:              false
   PandizzleWeightFileName:                 "MCC11_FHC_Pandizzle_TMVAClassification_BDTG_standard.weights.xml"
   PandrizzleWeightFileName:                "MCC11_FHC_Pandrizzle_TMVAClassification_BDTG_standard.weights.xml"
   EnhancedPandrizzleWeightFileName:        ""

--- a/dunereco/FDSelections/pandrizzle/PandrizzleAlg.cxx
+++ b/dunereco/FDSelections/pandrizzle/PandrizzleAlg.cxx
@@ -227,25 +227,25 @@ void FDSelection::PandrizzleAlg::InitialiseTrees() {
     BookTreeFloat(tree, "ModularShowerLargestProjectedGapSize");
 
     // For drawing purposes
-    BookTreeFloat(tree, "StartX");
-    BookTreeFloat(tree, "StartY");
-    BookTreeFloat(tree, "StartZ");
-    BookTreeFloat(tree, "EndX");
-    BookTreeFloat(tree, "EndY");
-    BookTreeFloat(tree, "EndZ");
-    BookTreeFloat(tree, "StartPX");
-    BookTreeFloat(tree, "StartPY");
-    BookTreeFloat(tree, "StartPZ");
-    BookTreeFloat(tree, "EndPX");
-    BookTreeFloat(tree, "EndPY");
-    BookTreeFloat(tree, "EndPZ");
+    //BookTreeFloat(tree, "StartX");
+    //BookTreeFloat(tree, "StartY");
+    //BookTreeFloat(tree, "StartZ");
+    //BookTreeFloat(tree, "EndX");
+    //BookTreeFloat(tree, "EndY");
+    //BookTreeFloat(tree, "EndZ");
+    //BookTreeFloat(tree, "StartPX");
+    //BookTreeFloat(tree, "StartPY");
+    //BookTreeFloat(tree, "StartPZ");
+    //BookTreeFloat(tree, "EndPX");
+    //BookTreeFloat(tree, "EndPY");
+    //BookTreeFloat(tree, "EndPZ");
 
-    fVarHolder.m_trajPositionX = std::vector<float>();
-    fVarHolder.m_trajPositionY = std::vector<float>();
-    fVarHolder.m_trajPositionZ = std::vector<float>();
-    tree->Branch("TrajPositionX", &fVarHolder.m_trajPositionX);
-    tree->Branch("TrajPositionY", &fVarHolder.m_trajPositionY);
-    tree->Branch("TrajPositionZ", &fVarHolder.m_trajPositionZ);
+    //fVarHolder.m_trajPositionX = std::vector<float>();
+    //fVarHolder.m_trajPositionY = std::vector<float>();
+    //fVarHolder.m_trajPositionZ = std::vector<float>();
+    //tree->Branch("TrajPositionX", &fVarHolder.m_trajPositionX);
+    //tree->Branch("TrajPositionY", &fVarHolder.m_trajPositionY);
+    //tree->Branch("TrajPositionZ", &fVarHolder.m_trajPositionZ);
   }
 }
 
@@ -371,8 +371,19 @@ void FDSelection::PandrizzleAlg::FillPandrizzleInfo(const art::Ptr<recob::Shower
     return;
   
   art::Ptr<recob::PFParticle> nu_pfp = dune_ana::DUNEAnaEventUtils::GetNeutrino(evt, fPFParticleModuleLabel);
-  art::Ptr<recob::Vertex> pNuVertex = dune_ana::DUNEAnaPFParticleUtils::GetVertex(nu_pfp, evt, fPFParticleModuleLabel);
-  TVector3 nuVertex = TVector3(pNuVertex->position().X(), pNuVertex->position().Y(), pNuVertex->position().Z());
+
+  TVector3 nuVertex = TVector3(0.f, 0.f, 0.f);
+
+  try
+  {
+    art::Ptr<recob::Vertex> pNuVertex = dune_ana::DUNEAnaPFParticleUtils::GetVertex(nu_pfp, evt, fPFParticleModuleLabel);
+    nuVertex = TVector3(pNuVertex->position().X(), pNuVertex->position().Y(), pNuVertex->position().Z());
+  }
+  catch(...)
+  {
+      return;
+  }
+
   TVector3 showerVertex = pShower->ShowerStart();
 
   fVarHolder.FloatVars["Displacement"] = std::min(static_cast<Float_t>((showerVertex - nuVertex).Mag()), 100.f);
@@ -418,11 +429,11 @@ void FDSelection::PandrizzleAlg::FillEnhancedPandrizzleInfo(const art::Ptr<recob
   art::FindManyP<larpandoraobj::PFParticleMetadata> metadataAssn(pfparticleListHandle, evt, fPFPMetadataLabel);
   std::vector<art::Ptr<larpandoraobj::PFParticleMetadata>> pfpMetadata = metadataAssn.at(pfp.key());
 
-  if (pfpMetadata.size() == 1)
+  if ((pfpMetadata.size() == 1) && (pfpMetadata[0]->GetPropertiesMap().find("PathwayLengthMin") != pfpMetadata[0]->GetPropertiesMap().end()))
   {
     larpandoraobj::PFParticleMetadata::PropertiesMap propertiesMap(pfpMetadata[0]->GetPropertiesMap());
 
-    fVarHolder.FloatVars["FoundConnectionPathway"] = propertiesMap.find("ElectronConnectionPathwayScore") != propertiesMap.end() ? 1.0 : 0.0;
+    fVarHolder.FloatVars["FoundConnectionPathway"] = propertiesMap.find("FoundConnectionPathway") != propertiesMap.end() ? 1.0 : 0.0;
     fVarHolder.FloatVars["ConnectionBDTScore"] = propertiesMap.find("ElectronConnectionPathwayScore") != propertiesMap.end() ? propertiesMap.at("ElectronConnectionPathwayScore") : -100.0;
     fVarHolder.FloatVars["PathwayLengthMin"] = propertiesMap.find("PathwayLengthMin") != propertiesMap.end() ? propertiesMap.at("PathwayLengthMin") : -100.0;
     fVarHolder.FloatVars["MaxShowerStartPathwayScatteringAngle2D"] = propertiesMap.find("MaxShowerStartPathwayScatteringAngle2D") != propertiesMap.end() ?
@@ -512,8 +523,18 @@ void FDSelection::PandrizzleAlg::FillBackupPandrizzleInfo(const art::Ptr<recob::
     fVarHolder.FloatVars["ModularShowerPathwayKink3D"] = std::min(modularShowerPathwayKink3D, 20.f);
 
     art::Ptr<recob::PFParticle> nu_pfp = dune_ana::DUNEAnaEventUtils::GetNeutrino(evt, fPFParticleModuleLabel);
-    art::Ptr<recob::Vertex> pNuVertex = dune_ana::DUNEAnaPFParticleUtils::GetVertex(nu_pfp, evt, fPFParticleModuleLabel);
-    TVector3 nuVertex = TVector3(pNuVertex->position().X(), pNuVertex->position().Y(), pNuVertex->position().Z());
+
+    TVector3 nuVertex = TVector3(0.f, 0.f, 0.f);
+
+    try
+    {
+        art::Ptr<recob::Vertex> pNuVertex = dune_ana::DUNEAnaPFParticleUtils::GetVertex(nu_pfp, evt, fPFParticleModuleLabel);
+        nuVertex = TVector3(pNuVertex->position().X(), pNuVertex->position().Y(), pNuVertex->position().Z());
+    }
+    catch(...)
+    {
+        return;
+    }
 
     SetInitialRegionVariables(nuVertex, trackStub);
 
@@ -1211,6 +1232,7 @@ FDSelection::PandrizzleAlg::Record FDSelection::PandrizzleAlg::RunPID(const art:
   fVarHolder.BoolVars["EnhancedPandrizzleVarsFilled"] = false;
   fVarHolder.BoolVars["BackupPandrizzleVarsFilled"] = false;
 
+  Reset(fInputsToReader);
   ResetTreeVariables();
   ProcessPFParticle(pfp, evt);
 
@@ -1278,7 +1300,7 @@ FDSelection::PandrizzleAlg::Record FDSelection::PandrizzleAlg::RunPID(const art:
     SetVar(kModularShowerMaxNShowerHits, fVarHolder.FloatVars["ModularShowerMaxNShowerHits"]);
   }
  
-  if (std::fabs(*fInputsToReader.at(kBDTMethod) - 2.f) > std::numeric_limits<float>::epsilon())
+  if (!(std::fabs(*fInputsToReader.at(kBDTMethod) - 2.f) < std::numeric_limits<float>::epsilon()))
       SetVar(kBDTMethod, 1);
 
   SetVar(kBackupPandrizzleScore, fReader.EvaluateMVA("BDTG"));


### PR DESCRIPTION
Hello, 

This PR implements some code changes to the FDSelections modules, these include:

- Modifications to the training tree branches to reduce the output file size
- Fixing a bug in PandrizzleAlg.cxx so the code doesn't crash when a nu vertex can't be found

Thanks!

Any questions, please reach out: i.mawby1@lancaster.ac.uk