### PR TITLE
Fix longest track

### DIFF
--- a/dunereco/FDSensOpt/CMakeLists.txt
+++ b/dunereco/FDSensOpt/CMakeLists.txt
@@ -135,6 +135,7 @@ cet_build_plugin(EnergyReco   art::module
                         larcore::Geometry_Geometry_service
                         larreco::Calorimetry
                         larreco::RecoAlg
+                        larpandora::LArPandoraInterface
                         lardataalg::DetectorInfo
                         lardataobj::RecoBase
                         larsim::MCCheater_BackTrackerService_service

--- a/dunereco/FDSensOpt/EnergyReco_module.cc
+++ b/dunereco/FDSensOpt/EnergyReco_module.cc
@@ -29,6 +29,7 @@
 #include "lardata/Utilities/AssociationUtil.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
 //DUNE
 #include "dunereco/FDSensOpt/FDSensOptData/EnergyRecoOutput.h"
 #include "dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.h"
@@ -121,12 +122,19 @@ art::Ptr<recob::Track> EnergyReco::GetLongestTrack(const art::Event &event)
 {
     art::Ptr<recob::Track> pTrack{};
     const std::vector<art::Ptr<recob::Track> > tracks(dune_ana::DUNEAnaEventUtils::GetTracks(event, fTrackLabel));
+    art::FindManyP<recob::PFParticle> fmPFParticle(tracks, event, fTrackLabel);
+    
     if (0 == tracks.size())
         return pTrack;
 
     double longestLength(std::numeric_limits<double>::lowest());
     for (unsigned int iTrack = 0; iTrack < tracks.size(); ++iTrack)
     {
+        if (fmPFParticle.isValid()){
+            std::vector<art::Ptr<recob::PFParticle>> pfp = fmPFParticle.at(iTrack);
+            if (!lar_pandora::LArPandoraHelper::IsTrack(pfp[0]))
+                continue;
+        }
         const double length(tracks[iTrack]->Length());
         if (length-longestLength > std::numeric_limits<double>::epsilon())
         {

--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.cc
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.cc
@@ -133,9 +133,9 @@ dune::EnergyRecoOutput NeutrinoEnergyRecoAlg::CalculateNeutrinoEnergy(const art:
 
     const std::vector<art::Ptr<recob::Hit> > electronHits(dune_ana::DUNEAnaHitUtils::GetHitsOnPlane(dune_ana::DUNEAnaShowerUtils::GetHits(pElectronShower, event, fShowerToHitLabel),2));
     const double electronEnergy(this->CalculateElectronEnergy(pElectronShower, event));
-    //ATTN yep this line is bugged.  It's deliberately bugged to maintain how the original code functioned
-    //Because of the small electron mass vs total energy deposition, this bug will have a very very small effect on the 4vector
-    const Momentum4_t electron4Momentum(this->CalculateParticle4Momentum(kElectronMass, electronEnergy, 
+    const double electronMomentum = std::sqrt(electronEnergy*(electronEnergy + 2*kElectronMass));
+
+    const Momentum4_t electron4Momentum(this->CalculateParticle4Momentum(kElectronMass, electronMomentum,
         pElectronShower->Direction().X(), pElectronShower->Direction().Y(), pElectronShower->Direction().Z()));
 
     EnergyRecoInputHolder energyRecoInputHolder(vertex, electron4Momentum, 


### PR DESCRIPTION
### Include PFParticle association for longest track

In the new versions, all PFParticles are treated as tracks and showers.
A shower-like event reconstructed as track can have a length many times
bigger then in reality.
Using recob::PFParticle to recob::Tracks association for searching
longest track helps avoiding this problem.

###  Proposed correction from electron energy 

I see the comment saying that:
`//ATTN yep this line is bugged.  It's deliberately bugged to maintain how the original code functioned
    //Because of the small electron mass vs total energy deposition, this bug will have a very very small effect on the 4vector`
    
Would it be ok to change it at this point? 

