### PR TITLE
DUNE FD Production phase 2 release

### DIFF
--- a/dunereco/DUNEPandora/pandoramodules_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodules_dune.fcl
@@ -32,6 +32,8 @@ dune35t_pandora.ShouldRunStitching:                                 true
 dunefd_pandora_neutrino:                                            @local::dune_pandora
 dunefd_pandora_neutrino.ConfigFile:                                 "PandoraSettings_Master_DUNEFD.xml"
 dunefd_pandora_neutrino.ShouldRunNeutrinoRecoOption:                true
+dunefd_pandora_neutrino.EnableMCParticles:                          true
+dunefd_pandora_neutrino.SimChannelModuleLabel:                      "tpcrawdecoder:simpleSC"
 
 dunefd_pandora_cosmic:                                              @local::dune_pandora
 dunefd_pandora_cosmic.ConfigFile:                                   "PandoraSettings_Master_DUNEFD.xml"

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_DUNEFD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_DUNEFD.xml
@@ -32,6 +32,8 @@
             <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
         <InputHitListName>CaloHitList2D</InputHitListName>
+        <InputMCParticleListName>Input</InputMCParticleListName>
+        <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
         <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
         <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_DUNEFD_VD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_DUNEFD_VD.xml
@@ -46,6 +46,8 @@
             <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
         <InputHitListName>CaloHitList2D</InputHitListName>
+        <InputMCParticleListName>Input</InputMCParticleListName>
+        <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
         <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
         <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD.xml
@@ -17,9 +17,9 @@
         <TrainingMode>false</TrainingMode>
         <OutputVertexListName>NeutrinoVertices3D_Pass1</OutputVertexListName>
         <CaloHitListNames>CaloHitListW CaloHitListU CaloHitListV</CaloHitListNames>
-        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_U_v04_03_00.pt</ModelFileNameU>
-        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_V_v04_03_00.pt</ModelFileNameV>
-        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_W_v04_03_00.pt</ModelFileNameW>
+        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_U_v04_06_00.pt</ModelFileNameU>
+        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_V_v04_06_00.pt</ModelFileNameV>
+        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_W_v04_06_00.pt</ModelFileNameW>
         <DistanceThresholds>0. 0.00275 0.00825 0.01925 0.03575 0.05775 0.08525 0.12375 0.15125 0.20625 0.26125 0.31625 0.37125 0.42625 0.50875 0.59125 0.67375 0.75625 0.85 1.0</DistanceThresholds>
         <Visualise>false</Visualise>
     </algorithm>
@@ -30,9 +30,9 @@
         <InputVertexListName>NeutrinoVertices3D_Pass1</InputVertexListName>
         <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
         <CaloHitListNames>CaloHitListW CaloHitListU CaloHitListV</CaloHitListNames>
-        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_U_v04_03_00.pt</ModelFileNameU>
-        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_V_v04_03_00.pt</ModelFileNameV>
-        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_W_v04_03_00.pt</ModelFileNameW>
+        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_U_v04_06_00.pt</ModelFileNameU>
+        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_V_v04_06_00.pt</ModelFileNameV>
+        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_W_v04_06_00.pt</ModelFileNameW>
         <ImageWidth>128</ImageWidth>
         <ImageHeight>128</ImageHeight>
         <DistanceThresholds>0. 0.00275 0.00825 0.01925 0.03575 0.05775 0.08525 0.12375 0.15125 0.20625 0.26125 0.31625 0.37125 0.42625 0.50875 0.59125 0.67375 0.75625 0.85 1.0</DistanceThresholds>
@@ -496,10 +496,10 @@
         <MCParticleListName>Input</MCParticleListName>
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <UseThreeDInformation>true</UseThreeDInformation>
-        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileName>
-        <MvaName>PfoCharacterisation</MvaName>
-        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileNameNoChargeInfo>
-        <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
+        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_HD_v04_06_00.xml</MvaFileName>
+        <MvaName>PreHierarchy</MvaName>
+        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_HD_v04_06_00.xml</MvaFileNameNoChargeInfo>
+        <MvaNameNoChargeInfo>PreHierarchy_NoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
         <PersistFeatures>true</PersistFeatures>
@@ -609,10 +609,10 @@
         <MCParticleListName>Input</MCParticleListName>
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <UseThreeDInformation>true</UseThreeDInformation>
-        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileName>
-        <MvaName>PfoCharacterisation</MvaName>
-        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileNameNoChargeInfo>
-        <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
+        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_HD_v04_06_00.xml</MvaFileName>
+        <MvaName>PostHierarchy</MvaName>
+        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_HD_v04_06_00.xml</MvaFileNameNoChargeInfo>
+        <MvaNameNoChargeInfo>PostHierarchy_NoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
         <PersistFeatures>true</PersistFeatures>

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD_VD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD_VD.xml
@@ -17,9 +17,9 @@
         <TrainingMode>false</TrainingMode>
         <OutputVertexListName>NeutrinoVertices3D_Pass1</OutputVertexListName>
         <CaloHitListNames>CaloHitListW CaloHitListU CaloHitListV</CaloHitListNames>
-        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_U_v04_03_00.pt</ModelFileNameU>
-        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_V_v04_03_00.pt</ModelFileNameV>
-        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_1_W_v04_03_00.pt</ModelFileNameW>
+        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_VD_Accel_1_U_v04_06_00.pt</ModelFileNameU>
+        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_VD_Accel_1_V_v04_06_00.pt</ModelFileNameV>
+        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_VD_Accel_1_W_v04_06_00.pt</ModelFileNameW>
         <DistanceThresholds>0. 0.00275 0.00825 0.01925 0.03575 0.05775 0.08525 0.12375 0.15125 0.20625 0.26125 0.31625 0.37125 0.42625 0.50875 0.59125 0.67375 0.75625 0.85 1.0</DistanceThresholds>
         <Visualise>false</Visualise>
     </algorithm>
@@ -30,9 +30,9 @@
         <InputVertexListName>NeutrinoVertices3D_Pass1</InputVertexListName>
         <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
         <CaloHitListNames>CaloHitListW CaloHitListU CaloHitListV</CaloHitListNames>
-        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_U_v04_03_00.pt</ModelFileNameU>
-        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_V_v04_03_00.pt</ModelFileNameV>
-        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_HD_Accel_2_W_v04_03_00.pt</ModelFileNameW>
+        <ModelFileNameU>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_VD_Accel_2_U_v04_06_00.pt</ModelFileNameU>
+        <ModelFileNameV>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_VD_Accel_2_V_v04_06_00.pt</ModelFileNameV>
+        <ModelFileNameW>PandoraNetworkData/PandoraNet_Vertex_DUNEFD_VD_Accel_2_W_v04_06_00.pt</ModelFileNameW>
         <ImageWidth>128</ImageWidth>
         <ImageHeight>128</ImageHeight>
         <DistanceThresholds>0. 0.00275 0.00825 0.01925 0.03575 0.05775 0.08525 0.12375 0.15125 0.20625 0.26125 0.31625 0.37125 0.42625 0.50875 0.59125 0.67375 0.75625 0.85 1.0</DistanceThresholds>
@@ -41,7 +41,16 @@
 
     <!-- TwoDReconstruction -->
     <algorithm type = "LArClusteringParent">
-        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation"/>
+        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation">
+            <MinMipFraction>0.3</MinMipFraction>
+        </algorithm>
+        <InputCaloHitListName>CaloHitListU</InputCaloHitListName>
+        <ClusterListName>ClustersU</ClusterListName>
+        <ReplaceCurrentCaloHitList>true</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation" />
         <InputCaloHitListName>CaloHitListU</InputCaloHitListName>
         <ClusterListName>ClustersU</ClusterListName>
         <ReplaceCurrentCaloHitList>true</ReplaceCurrentCaloHitList>
@@ -63,7 +72,16 @@
     <algorithm type = "LArHitWidthClusterMerging"/>
 
     <algorithm type = "LArClusteringParent">
-        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation"/>
+        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation">
+            <MinMipFraction>0.3</MinMipFraction>
+        </algorithm>
+        <InputCaloHitListName>CaloHitListV</InputCaloHitListName>
+        <ClusterListName>ClustersV</ClusterListName>
+        <ReplaceCurrentCaloHitList>true</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation" />
         <InputCaloHitListName>CaloHitListV</InputCaloHitListName>
         <ClusterListName>ClustersV</ClusterListName>
         <ReplaceCurrentCaloHitList>true</ReplaceCurrentCaloHitList>
@@ -85,7 +103,16 @@
     <algorithm type = "LArHitWidthClusterMerging"/>
 
     <algorithm type = "LArClusteringParent">
-        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation"/>
+        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation">
+            <MinMipFraction>0.3</MinMipFraction>
+        </algorithm>
+        <InputCaloHitListName>CaloHitListW</InputCaloHitListName>
+        <ClusterListName>ClustersW</ClusterListName>
+        <ReplaceCurrentCaloHitList>true</ReplaceCurrentCaloHitList>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+    <algorithm type = "LArClusteringParent">
+        <algorithm type = "LArTrackClusterCreation" description = "ClusterFormation" />
         <InputCaloHitListName>CaloHitListW</InputCaloHitListName>
         <ClusterListName>ClustersW</ClusterListName>
         <ReplaceCurrentCaloHitList>true</ReplaceCurrentCaloHitList>
@@ -485,10 +512,10 @@
         <MCParticleListName>Input</MCParticleListName>
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <UseThreeDInformation>true</UseThreeDInformation>
-        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileName>
-        <MvaName>PfoCharacterisation</MvaName>
-        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileNameNoChargeInfo>
-        <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
+        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_VD_v04_06_00.xml</MvaFileName>
+        <MvaName>PreHierarchy</MvaName>
+        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_VD_v04_06_00.xml</MvaFileNameNoChargeInfo>
+        <MvaNameNoChargeInfo>PreHierarchy_NoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
         <PersistFeatures>true</PersistFeatures>
@@ -598,10 +625,10 @@
         <MCParticleListName>Input</MCParticleListName>
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <UseThreeDInformation>true</UseThreeDInformation>
-        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileName>
-        <MvaName>PfoCharacterisation</MvaName>
-        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_v03_26_00.xml</MvaFileNameNoChargeInfo>
-        <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
+        <MvaFileName>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_VD_v04_06_00.xml</MvaFileName>
+        <MvaName>PostHierarchy</MvaName>
+        <MvaFileNameNoChargeInfo>PandoraMVAData/PandoraBdt_PfoCharacterisation_DUNEFD_VD_v04_06_00.xml</MvaFileNameNoChargeInfo>
+        <MvaNameNoChargeInfo>PostHierarchy_NoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
         <PersistFeatures>true</PersistFeatures>


### PR DESCRIPTION
This PR contains updates targeting phase 2 of the DUNE FD production, incorporating new weight files. This PR should be applied in conjunction with the [larpandoracontent PR](https://github.com/LArSoft/larpandoracontent/pull/58), which updates clustering behaviour to accommodate larger differences in wire/strip pitch between planes (as is the case in the vertical drift detector).