### PR TITLE
Update parameters for track momentum and add options

### DIFF
--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.h
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/NeutrinoEnergyRecoAlg.h
@@ -293,6 +293,14 @@ class NeutrinoEnergyRecoAlg
         double fIntNuEHadEn;                                     ///< the hadronic energy correction intercept for nue
         double fDistanceToWallThreshold;                         ///< the min distance from a detector wall to be considered contained
         double fMuonRangeToMCSThreshold;                         ///< the ratio threshold at which MCS is used for contained muons
+
+        std::string fMCSMethod;                                  ///< Method os MCS, Chi2 or Log Likelihood (LLHD)
+        double fMinTrackLengthMCS;                               ///< the minimum track length in cm to compute MCS
+        double fMaxTrackLengthMCS;                               ///< the maximum track length in cm to compute MCS
+        double fSegmentSizeMCS;                                  ///< the segment length in cm to compute scattered angle MCS
+        int fMaxMomentumMCS;                                     ///< the maximum momentum to be fitted
+        int fStepsMomentumMCS;                                   ///< for LLHD, energy steps to minimize
+        int fMaxResolutionMCS;                                   ///< for LLHD, angle resolution is fitted, set 0 to keep at 2 mrad
         double fRecombFactor;                                    ///< the average reccombination factor
 
         std::string fTrackLabel;                                 ///< the track label

--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/neutrinoenergyrecoalg_dune.fcl
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/neutrinoenergyrecoalg_dune.fcl
@@ -21,6 +21,14 @@ dune_neutrinoenergyrecoalg:
     DistanceToWallThreshold: 20.0 
     MuonRangeToMCSThreshold: 0.7
     RecombFactor:            0.63
+
+    MCSMethod:              "Chi2"     # Chi2 or "LLHD"
+    MinTrackLengthMCS:      100.       # cm
+    MaxTrackLengthMCS:      1350.      # cm
+    SegmentSizeMCS:         10.        # cm
+    MaxMomentumMCS:         7500       # MeV (integer)
+    StepsMomentumMCS:       10         # MeV (integer)
+    MaxResolutionMCS:       0          # mrad (integer), set zero fixes at 2 mrad
 }
 
 dunevd_neutrinoenergyrecoalg:

--- a/dunereco/FDSensOpt/energyreco.fcl
+++ b/dunereco/FDSensOpt/energyreco.fcl
@@ -22,6 +22,12 @@ dunefd_nuenergyreco_pmtrack:
     ShowerToHitLabel:        "emshower"
     HitToSpacePointLabel:   "pmtrack"
 
+    # LongestTrackMethod
+    # '0' is the standard computation: by range or MCS, depending on containment and on MuonRangeToMCSThreshold
+    # '1' forcefully use only range.
+    # '2' forcefully use only mcs
+    LongestTrackMethod:     0
+
     NeutrinoEnergyRecoAlg:   @local::dune10kt_neutrinoenergyrecoalg
 }
 


### PR DESCRIPTION
Hello again, 

Following my mistake on the last commit, now PR https://github.com/DUNE/dunereco/pull/60 https://github.com/LArSoft/larreco/pull/60 has been merged, so my changes can be applied.

These are my comments on the previous commit:

---

following the discussion on Reco/Sim WG. I have looked in the TrackMomentumCalculator algorithms and I found a few hard-coded values. 
I have updated it and made [this](https://github.com/LArSoft/larreco/pull/60#issue-1924669486)  pull request. 

I've added parameters to be set with fhicl files:

```
MinTrackLengthMCS:      100.       # cm
MaxTrackLengthMCS:      1350.      # cm
SegmentSizeMCS:         10.        # cm
MaxMomentumMCS:         7500       # MeV (integer)
StepsMomentumMCS:       10         # MeV (integer)
MaxResolutionMCS:       0          # mrad (integer), set zero fixes at 2 mrad
 ```
 
This values are the ones that were hard-coded. So the behavior  should not change. 
 
I also added a few options: 
```
 MCSMethod:              "Chi2"     # Chi2 or "LLHD"
```
and
```
LongestTrackMethod:     0
```

This allows to forcefully compute the energy my range or multiple coulomb scattering. Allowing for debugging.
Again, the values set should keep the behavior of the producer. 

I've added one actual change in the code [here](https://github.com/DUNE/dunereco/commit/6a9d6e8f11a604fb13a6c05ac2fb406a9f440e1c#diff-6343c8f889eebf244b2a36ea9426387564f76568f5702175ca189b4b8f8d3fe6R222), in which I added a check for a valid MCS returned momentum. If this check is not done, the momentum equal `-1` might be returned and the "reconstructed energy" will be `sqrt( 1 + 105.6^2)`. 


