### PR TITLE
Addressing dictionnary error with AngularRecoOutput

### DIFF
--- a/dunereco/FDSensOpt/FDSensOptData/AngularRecoOutput.h
+++ b/dunereco/FDSensOpt/FDSensOptData/AngularRecoOutput.h
@@ -5,7 +5,7 @@
 #include "Math/GenVector/PxPyPzE4D.h" 
 #include "Math/GenVector/LorentzVector.h" 
 
-using Point_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
+using Point3D_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
 using Direction_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
 using Momentum_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
 
@@ -17,7 +17,7 @@ namespace dune
 
     int recoMethodUsed;         // 1 = longest reco direction, 2 = shower with highest charge direction, -1 = not set 
 
-    Point_t fRecoVertex;
+    Point3D_t fRecoVertex;
     Direction_t fRecoDirection;
   };
 }

--- a/dunereco/FDSensOpt/FDSensOptData/classes.h
+++ b/dunereco/FDSensOpt/FDSensOptData/classes.h
@@ -1,5 +1,6 @@
 #include "dunereco/FDSensOpt/FDSensOptData/MVASelectPID.h"
 #include "dunereco/FDSensOpt/FDSensOptData/EnergyRecoOutput.h"
+#include "dunereco/FDSensOpt/FDSensOptData/AngularRecoOutput.h"
 
 #include "canvas/Persistency/Common/Assns.h"
 #include "canvas/Persistency/Common/Wrapper.h"

--- a/dunereco/FDSensOpt/FDSensOptData/classes_def.xml
+++ b/dunereco/FDSensOpt/FDSensOptData/classes_def.xml
@@ -11,11 +11,16 @@
    <version ClassVersion="10" checksum="2518891177"/>
   </class>
 
+  <class name="dune::AngularRecoOutput" />
+
   <class name="art::Ptr<dunemva::MVASelectPID>" />
   <class name="art::Wrapper<dunemva::MVASelectPID >" />
 
   <class name="art::Ptr<dune::EnergyRecoOutput>" />
   <class name="art::Wrapper<dune::EnergyRecoOutput>" />
+
+  <class name="art::Ptr<dune::AngularRecoOutput>" />
+  <class name="art::Wrapper<dune::AngularRecoOutput>" />
 
   <class name="std::pair< art::Ptr<dune::EnergyRecoOutput>, art::Ptr<recob::Track>      >"    />
   <class name="std::pair< art::Ptr<dune::EnergyRecoOutput>, art::Ptr<recob::Shower>      >"    />
@@ -30,6 +35,11 @@
   <class name="art::Wrapper< art::Assns<dune::EnergyRecoOutput, recob::Shower, void> >" />
   <class name="art::Wrapper< art::Assns<recob::Track, dune::EnergyRecoOutput, void> >" />
   <class name="art::Wrapper< art::Assns<recob::Shower, dune::EnergyRecoOutput, void> >" />
+
+  <class name="art::Wrapper< art::Assns<dune::AngularRecoOutput, recob::Track, void> >" />
+  <class name="art::Wrapper< art::Assns<dune::AngularRecoOutput, recob::Shower, void> >" />
+  <class name="art::Wrapper< art::Assns<recob::Track, dune::AngularRecoOutput, void> >" />
+  <class name="art::Wrapper< art::Assns<recob::Shower, dune::AngularRecoOutput, void> >" />
 </lcgdict>
 
 

--- a/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.cc
+++ b/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.cc
@@ -55,13 +55,13 @@ dune::AngularRecoOutput NeutrinoAngularRecoAlg::CalculateNeutrinoAngle(const art
         mf::LogWarning("NeutrinoAngularRecoAlg") << " Cannot access the muon track which is needed for this angular reconstruction method.\n"
         << "Not able to calculate neutrino direction" << std::endl;
 
-        Point_t vertex(0,0,0);
+        Point3D_t vertex(0,0,0);
         Direction_t direction(0,0,0);
         AngularRecoInputHolder angularRecoInputHolder(vertex, direction, kRecoMethodNotSet);
         return this->ReturnNeutrinoAngle(angularRecoInputHolder);
     }
 
-    Point_t vertex(pMuonTrack->Start().X(), pMuonTrack->Start().Y(), pMuonTrack->Start().Z());
+    Point3D_t vertex(pMuonTrack->Start().X(), pMuonTrack->Start().Y(), pMuonTrack->Start().Z());
 
     TVector3 dir_start;
     dir_start = pMuonTrack->VertexDirection<TVector3>();
@@ -82,14 +82,14 @@ dune::AngularRecoOutput NeutrinoAngularRecoAlg::CalculateNeutrinoAngle(const art
         mf::LogWarning("NeutrinoAngularRecoAlg") 
         << " Cannot access the electron shower which is needed for this angular reconstruction method.\n"
         << "Not able to calculate neutrino direction" << std::endl;
-        Point_t vertex(0,0,0);
+        Point3D_t vertex(0,0,0);
         Direction_t direction(0,0,0);
         AngularRecoInputHolder angularRecoInputHolder(vertex, direction, kRecoMethodNotSet);
         return this->ReturnNeutrinoAngle(angularRecoInputHolder);
     }
 
 
-    Point_t vertex(pElectronShower->ShowerStart().X(), pElectronShower->ShowerStart().Y(), pElectronShower->ShowerStart().Z());
+    Point3D_t vertex(pElectronShower->ShowerStart().X(), pElectronShower->ShowerStart().Y(), pElectronShower->ShowerStart().Z());
 
     TVector3 const& dir_start = pElectronShower->Direction();
     Direction_t direction(dir_start.X(), dir_start.Y(), dir_start.Z());
@@ -105,7 +105,7 @@ dune::AngularRecoOutput NeutrinoAngularRecoAlg::CalculateNeutrinoAngle(const std
                                                                        const art::Event &event)
 {
     //Using all the reco particles to determine the angle
-    Point_t vertex(0,0,0); //No meaning vertex value is filled with this method
+    Point3D_t vertex(0,0,0); //No meaning vertex value is filled with this method
 
     if (pTracks.size() == 0 && pShowers.size() == 0)
     {
@@ -137,7 +137,7 @@ dune::AngularRecoOutput NeutrinoAngularRecoAlg::CalculateNeutrinoAngle(const art
                                                                        const art::Event &event)
 {
     //Using all the reco particles to determine the angle, but using the longest track as muon
-    Point_t vertex(0,0,0); //No meaning vertex value is filled with this method
+    Point3D_t vertex(0,0,0); //No meaning vertex value is filled with this method
 
     if (!pMuonTrack.isAvailable() || pMuonTrack.isNull())
     {

--- a/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.h
+++ b/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.h
@@ -126,12 +126,12 @@ class NeutrinoAngularRecoAlg
             * @param  nuDirection the reconstructed nu direction
             * @param  angularRecoMethod the neutrino direction reconstruction method
             */
-            AngularRecoInputHolder(const Point_t &vertex, const Direction_t &nuDirection, const AngularRecoMethod angularRecoMethod) :
+            AngularRecoInputHolder(const Point3D_t &vertex, const Direction_t &nuDirection, const AngularRecoMethod angularRecoMethod) :
                 fVertex(vertex),
                 fNuDirection(nuDirection),
                 fAngularRecoMethod(angularRecoMethod) {};
 
-            const Point_t fVertex;                                   ///< the reconstructed vertex
+            const Point3D_t fVertex;                                   ///< the reconstructed vertex
             const Direction_t fNuDirection;                       ///< the reconstructed neutrino direction
             const AngularRecoMethod fAngularRecoMethod;                ///< the neutrino angle reconstruction method
         };


### PR DESCRIPTION
Trying to address an error obtained while running the CAFMaker (but not the Anatree for some reason):

```
    No dictionary found for the following classes:

         art::Assns<dune::AngularRecoOutput,recob::Shower,void>
         art::Wrapper<art::Assns<dune::AngularRecoOutput,recob::Shower,void> >
         art::Wrapper<art::Assns<recob::Shower,dune::AngularRecoOutput,void> >

    Most likely they were never generated, but it may be that they were generated in the wrong package.

    Please add (or move) the specification

         <class name="MyClassName"/>

    to the appropriate classes_def.xml file.

    Also, if this class has any transient members,
    you need to specify them in classes_def.xml.
```

I tried to mimic what is available for `EnergyRecoOutput`, but I am not fully certain that all the modifications are ok.