### PR TITLE
Addressing dictionnary error with AngularRecoOutput

### DIFF
--- a/dunereco/FDSensOpt/FDSensOptData/AngularRecoOutput.h
+++ b/dunereco/FDSensOpt/FDSensOptData/AngularRecoOutput.h
@@ -5,12 +5,13 @@
 #include "Math/GenVector/PxPyPzE4D.h" 
 #include "Math/GenVector/LorentzVector.h" 
 
-using Point_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
-using Direction_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
-using Momentum_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
 
 namespace dune
 {
+  using Point_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
+  using Direction_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
+  using Momentum_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
+
   class AngularRecoOutput
   {
   public:

--- a/dunereco/FDSensOpt/FDSensOptData/EnergyRecoOutput.h
+++ b/dunereco/FDSensOpt/FDSensOptData/EnergyRecoOutput.h
@@ -5,11 +5,12 @@
 #include "Math/GenVector/PxPyPzE4D.h" 
 #include "Math/GenVector/LorentzVector.h" 
 
-using Point_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
-using Position4_t = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>;
 
 namespace dune
 {
+  using Point_t = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>>;
+  using Position4_t = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>;
+
   class EnergyRecoOutput
   {
   public:

--- a/dunereco/FDSensOpt/FDSensOptData/classes.h
+++ b/dunereco/FDSensOpt/FDSensOptData/classes.h
@@ -1,5 +1,6 @@
 #include "dunereco/FDSensOpt/FDSensOptData/MVASelectPID.h"
 #include "dunereco/FDSensOpt/FDSensOptData/EnergyRecoOutput.h"
+#include "dunereco/FDSensOpt/FDSensOptData/AngularRecoOutput.h"
 
 #include "canvas/Persistency/Common/Assns.h"
 #include "canvas/Persistency/Common/Wrapper.h"

--- a/dunereco/FDSensOpt/FDSensOptData/classes_def.xml
+++ b/dunereco/FDSensOpt/FDSensOptData/classes_def.xml
@@ -11,11 +11,16 @@
    <version ClassVersion="10" checksum="2518891177"/>
   </class>
 
+  <class name="dune::AngularRecoOutput" />
+
   <class name="art::Ptr<dunemva::MVASelectPID>" />
   <class name="art::Wrapper<dunemva::MVASelectPID >" />
 
   <class name="art::Ptr<dune::EnergyRecoOutput>" />
   <class name="art::Wrapper<dune::EnergyRecoOutput>" />
+
+  <class name="art::Ptr<dune::AngularRecoOutput>" />
+  <class name="art::Wrapper<dune::AngularRecoOutput>" />
 
   <class name="std::pair< art::Ptr<dune::EnergyRecoOutput>, art::Ptr<recob::Track>      >"    />
   <class name="std::pair< art::Ptr<dune::EnergyRecoOutput>, art::Ptr<recob::Shower>      >"    />
@@ -30,6 +35,16 @@
   <class name="art::Wrapper< art::Assns<dune::EnergyRecoOutput, recob::Shower, void> >" />
   <class name="art::Wrapper< art::Assns<recob::Track, dune::EnergyRecoOutput, void> >" />
   <class name="art::Wrapper< art::Assns<recob::Shower, dune::EnergyRecoOutput, void> >" />
+
+  <class name="art::Assns<dune::AngularRecoOutput,recob::Shower,void>" />
+  <class name="art::Assns<recob::Shower,dune::AngularRecoOutput,void>" />
+  <class name="art::Wrapper<art::Assns<dune::AngularRecoOutput,recob::Shower,void> >" />
+  <class name="art::Wrapper<art::Assns<recob::Shower,dune::AngularRecoOutput,void> >" />
+
+  <class name="art::Assns<dune::AngularRecoOutput,recob::Track,void>" />
+  <class name="art::Assns<recob::Track,dune::AngularRecoOutput,void>" />
+  <class name="art::Wrapper<art::Assns<dune::AngularRecoOutput,recob::Track,void> >" />
+  <class name="art::Wrapper<art::Assns<recob::Track,dune::AngularRecoOutput,void> >" />
 </lcgdict>
 
 


### PR DESCRIPTION
Fixing the lack of definition of `AngularRecoOutput` related objects in `classes_def.xml`.
Had to move the `using` declarations of `AngularRecoOutput.h` and `EnergyRecoOutput.h` to a different scope to avoid some conflicts. 