### PR TITLE
support dnn roi training for pdhd

### DIFF
--- a/dunereco/DUNEWireCell/fhicl/pdhd_wirecell_sim_deposplat.fcl
+++ b/dunereco/DUNEWireCell/fhicl/pdhd_wirecell_sim_deposplat.fcl
@@ -12,10 +12,10 @@ services:
   RandomNumberGenerator: {} #ART native random number generator
   message:              @local::dune_message_services_prod
   FileCatalogMetadata:  @local::art_file_catalog_mc
-                        @table::protodunevd_reco_services
+                        @table::protodunehd_reco_services
   #ChannelStatusService: @local::pdsp_channel_status
   IFDH: {}
-  DetectorPropertiesService:  @local::protodunevd_detproperties
+  DetectorPropertiesService:  @local::protodune_detproperties
 }
 
 
@@ -31,18 +31,18 @@ physics: {
 
   producers: {
     rns:            { module_type: "RandomNumberSaver" }
-    wclsdatavd:         @local::protodunevd_nfspimg
+    wirecell:         @local::wirecell_pdhd_sim_deposplat
   }
 
-  reco: [ rns,
-        wclsdatavd
+reco: [ rns,
+        wirecell
         ]
 
   stream1:  [ out1 ]
 
   trigger_paths: [reco]
 
-  end_paths:     [ ] # [stream1]
+  end_paths:     [stream1]
 }
 
 outputs:
@@ -50,8 +50,8 @@ outputs:
  out1:
  {
    module_type: RootOutput
-   fileName:    "%ifb_reco.root"
-   dataTier:    "full-reconstructed"
+   fileName:    "%ifb_deposplat.root"
+   dataTier:    "simulated"
    outputCommands: [ "keep *", "drop *_reco3d_noreg_*", "drop *_reco3d_pre_*" ]
    compressionLevel: 1 #zlib argument (0-9)
    fastCloning: true

--- a/dunereco/DUNEWireCell/fhicl/protodunevd_wirecell_sim_deposplat.fcl
+++ b/dunereco/DUNEWireCell/fhicl/protodunevd_wirecell_sim_deposplat.fcl
@@ -34,7 +34,7 @@ physics: {
     wirecell:         @local::wirecell_protodunevd_sim_deposplat
   }
 
-reco: [ rns,
+  reco: [ rns,
         wirecell
         ]
 
@@ -42,7 +42,7 @@ reco: [ rns,
 
   trigger_paths: [reco]
 
-  end_paths:     [stream1]
+  end_paths:     [ ] # [stream1]
 }
 
 outputs:

--- a/dunereco/DUNEWireCell/pdhd/dnnroi.jsonnet
+++ b/dunereco/DUNEWireCell/pdhd/dnnroi.jsonnet
@@ -1,0 +1,85 @@
+// This produces a function to configure DNN-ROI for one APA given
+// anode and torch service (ts) objects.
+// 
+// The prefix is prepended to all internal node names if uniqueness
+// beyond anode ID is needed.  The output_scale allows for an ad-hoc
+// scaling of dnnroi output.  The U and W planes will go through
+// dnnroi while hte W plane will be shunted.  What comes out will be a
+// unified frame with frame tag "dnnspN" where "N" is the anode ID.
+
+local wc = import "wirecell.jsonnet";
+local pg = import "pgraph.jsonnet";
+
+
+function (anode, ts, prefix="dnnroi", output_scale=1.0) 
+    local apaid = anode.data.ident;
+    local prename = prefix + std.toString(apaid);
+    local intags = ['loose_lf%d'%apaid, 'mp2_roi%d'%apaid,
+                     'mp3_roi%d'%apaid];
+
+    local dnnroi_u = pg.pnode({
+        type: "DNNROIFinding",
+        name: prename+"u",
+        data: {
+            anode: wc.tn(anode),
+            plane: 0,
+            intags: intags,
+            decon_charge_tag: "decon_charge%d" %apaid,
+            outtag: "dnnsp%du"%apaid,
+            output_scale: output_scale,
+            forward: wc.tn(ts)
+        }
+    }, nin=1, nout=1, uses=[ts, anode]);
+    local dnnroi_v = pg.pnode({
+        type: "DNNROIFinding",
+        name: prename+"v",
+        data: {
+            anode: wc.tn(anode),
+            plane: 1,
+            intags: intags,
+            decon_charge_tag: "decon_charge%d" %apaid,
+            outtag: "dnnsp%dv"%apaid,
+            output_scale: output_scale,
+            forward: wc.tn(ts)
+        }
+    }, nin=1, nout=1, uses=[ts, anode]);
+    local dnnroi_w = pg.pnode({
+        type: "PlaneSelector",
+        name: prename+"w",
+        data: {
+            anode: wc.tn(anode),
+            plane: 2,
+            tags: ["gauss%d"%apaid],
+            tag_rules: [{
+                frame: {".*":"DNNROIFinding"},
+                trace: {["gauss%d"%apaid]:"dnnsp%dw"%apaid},
+            }],
+        }
+    }, nin=1, nout=1, uses=[anode]);
+
+    local dnnpipes = [dnnroi_u, dnnroi_v, dnnroi_w];
+    local dnnfanout = pg.pnode({
+        type: "FrameFanout",
+        name: prename,
+        data: {
+            multiplicity: 3
+        }
+    }, nin=1, nout=3);
+
+    local dnnfanin = pg.pnode({
+        type: "FrameFanin",
+        name: prename,
+        data: {
+            multiplicity: 3,
+            tag_rules: [{
+                frame: {".*": "dnnsp%d" % apaid},
+                // trace: {".*": "dnnsp%d" % apaid},
+            } for plane in ["u", "v", "w"]]
+        },
+    }, nin=3, nout=1);
+    
+    pg.intern(innodes=[dnnfanout],
+              outnodes=[dnnfanin],
+              centernodes=dnnpipes,
+              edges=[pg.edge(dnnfanout, dnnpipes[ind], ind, 0) for ind in [0,1,2]] +
+              [pg.edge(dnnpipes[ind], dnnfanin, 0, ind) for ind in [0,1,2]])

--- a/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-deposplat.jsonnet
+++ b/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-deposplat.jsonnet
@@ -1,0 +1,356 @@
+
+local g = import 'pgraph.jsonnet';
+local f = import 'pgrapher/common/funcs.jsonnet';
+local wc = import 'wirecell.jsonnet';
+
+local io = import 'pgrapher/common/fileio.jsonnet';
+local tools_maker = import 'pgrapher/common/tools.jsonnet';
+
+local params = import 'pgrapher/experiment/pdhd/simparams.jsonnet';
+
+// local tools = tools_maker(params);
+local btools = tools_maker(params);
+local tools = btools {
+    anodes : [btools.anodes[0], ],
+};
+
+local sim_maker = import 'pgrapher/experiment/pdhd/sim.jsonnet';
+local sim = sim_maker(params, tools);
+
+local nanodes = std.length(tools.anodes);
+local anode_iota = std.range(0, nanodes-1);
+
+local wcls_maker = import "pgrapher/ui/wcls/nodes.jsonnet";
+local wcls = wcls_maker(params, tools);
+local wcls_input = {
+    depos: wcls.input.depos(name="", art_tag="IonAndScint"),
+};
+
+local mega_anode = {
+  type: 'MegaAnodePlane',
+  name: 'meganodes',
+  data: {
+    anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+  },
+};
+local wcls_output = {
+    // ADC output from simulation
+    sim_digits: g.pnode({
+      type: 'wclsFrameSaver',
+      name: 'simdigits',
+      data: {
+        anode: wc.tn(mega_anode),
+        digitize: true,  // true means save as RawDigit, else recob::Wire
+        frame_tags: ['daq'],
+        // nticks: params.daq.nticks,
+        // chanmaskmaps: ['bad'],
+      },
+    }, nin=1, nout=1, uses=[mega_anode]),
+
+    // The noise filtered "ADC" values.  These are truncated for
+    // art::Event but left as floats for the WCT SP.  Note, the tag
+    // "raw" is somewhat historical as the output is not equivalent to
+    // "raw data".
+    nf_digits: wcls.output.digits(name="nfdigits", tags=["raw"]),
+
+    // The output of signal processing.  Note, there are two signal
+    // sets each created with its own filter.  The "gauss" one is best
+    // for charge reconstruction, the "wiener" is best for S/N
+    // separation.  Both are used in downstream WC code.
+    sp_signals: wcls.output.signals(name="spsignals", tags=["gauss", "wiener"]),
+
+    // save "threshold" from normal decon for each channel noise
+    // used in imaging
+    sp_thresholds: wcls.output.thresholds(name="spthresholds", tags=["threshold"]),
+};
+
+//local deposio = io.numpy.depos(output);
+local drifter = sim.drifter;
+// local bagger = sim.make_bagger();
+local bagger = [sim.make_bagger("bagger%d"%n) for n in anode_iota];
+
+// signal plus noise pipelines
+//local sn_pipes = sim.signal_pipelines;
+local sn_pipes = sim.splusn_pipelines;
+
+// local perfect = import 'pgrapher/experiment/pdhd/chndb-perfect.jsonnet';
+local base = import 'pgrapher/experiment/pdhd/chndb-base.jsonnet';
+local chndb = [{
+  type: 'OmniChannelNoiseDB',
+  name: 'ocndbperfect%d' % n,
+  // data: perfect(params, tools.anodes[n], tools.field, n),
+  data: base(params, tools.anodes[n], tools.field, n),
+  uses: [tools.anodes[n], tools.field],  // pnode extension
+} for n in anode_iota];
+
+//local chndb_maker = import 'pgrapher/experiment/pdhd/chndb.jsonnet';
+//local noise_epoch = "perfect";
+//local noise_epoch = "after";
+//local chndb_pipes = [chndb_maker(params, tools.anodes[n], tools.fields[n]).wct(noise_epoch)
+//                for n in std.range(0, std.length(tools.anodes)-1)];
+local nf_maker = import 'pgrapher/experiment/pdhd/nf.jsonnet';
+// local nf_pipes = [nf_maker(params, tools.anodes[n], chndb_pipes[n]) for n in std.range(0, std.length(tools.anodes)-1)];
+local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in anode_iota];
+
+local sp_maker = import 'pgrapher/experiment/pdhd/sp.jsonnet';
+local sp = sp_maker(params, tools, { sparse: true, use_roi_debug_mode: true, use_multi_plane_protection: true, mp_tick_resolution: 4, });
+local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
+
+local deposplats = [sim.make_ductor('splat%d'%n, tools.anodes[n], tools.pirs[0], 'DepoSplat', 'ductor%d'%n) for n in anode_iota] ;
+
+local rng = tools.random;
+local wcls_simchannel_sink = g.pnode({
+    type: 'wclsSimChannelSink',
+    name: 'postdrift',
+    data: {
+      artlabel: "simpleSC",    // where to save in art::Event
+      anodes_tn: [wc.tn(anode) for anode in tools.anodes],  
+      rng: wc.tn(rng),
+      tick: 0.5*wc.us,
+      start_time: -0.25*wc.ms,
+      readout_time: self.tick*6000,
+      nsigma: 3.0,
+      drift_speed: params.lar.drift_speed,
+      u_to_rp: 90.58*wc.mm,
+      v_to_rp: 95.29*wc.mm,
+      y_to_rp: 100*wc.mm,
+      u_time_offset: 0.0*wc.us,
+      v_time_offset: 0.0*wc.us,
+      y_time_offset: 0.0*wc.us,
+      use_energy: true,
+    },
+}, nin=1, nout=1, uses=tools.anodes);
+
+local magoutput = 'g4-rec-0.root';
+local magnify = import 'pgrapher/experiment/pdhd/magnify-sinks.jsonnet';
+local sinks = magnify(tools, magoutput);
+
+local hio_truth = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_truth%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        trace_tags: ['ductor%d'%n],
+        filename: "g4-tru-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+local hio_orig = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_orig%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        trace_tags: ['orig%d'%n],
+        filename: "g4-rec-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+local hio_sp = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_sp%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        trace_tags: ['loose_lf%d' % n
+        , 'tight_lf%d' % n
+        , 'cleanup_roi%d' % n
+        , 'break_roi_1st%d' % n
+        , 'break_roi_2nd%d' % n
+        , 'shrink_roi%d' % n
+        , 'extend_roi%d' % n
+        , 'mp3_roi%d' % n
+        , 'mp2_roi%d' % n
+        , 'decon_charge%d' % n
+        , 'gauss%d' % n],
+        filename: "g4-rec-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+local hio_dnn = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_dnn%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        // trace_tags: ['dnn_sp%d' % n],
+        trace_tags: ['dnnsp%d' % n],
+        filename: "g4-rec-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+local rio_orig = [g.pnode({
+      type: 'ExampleROOTAna',
+      name: 'rio_orig_apa%d' % n,
+      data: {
+        output_filename: "g4-rec-%d.root" % n,
+        anode: wc.tn(tools.anodes[n]),
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+local rio_nf = [g.pnode({
+      type: 'ExampleROOTAna',
+      name: 'rio_nf_apa%d' % n,
+      data: {
+        output_filename: "g4-rec-%d.root" % n,
+        anode: wc.tn(tools.anodes[n]),
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+local rio_sp = [g.pnode({
+      type: 'ExampleROOTAna',
+      name: 'rio_sp_apa%d' % n,
+      data: {
+        output_filename: "g4-rec-%d.root" % n,
+        anode: wc.tn(tools.anodes[n]),
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+// Note: better switch to layers
+local dnnroi = import 'pgrapher/experiment/pdhd/dnnroi.jsonnet';
+local ts = {
+    type: "TorchService",
+    name: "dnnroi",
+    data: {
+        // model: "ts-model/unet-l23-cosmic500-e50.ts",
+        model: "ts-model/CP49.ts",
+        device: "cpu", // "gpucpu",
+        concurrency: 1,
+    },
+};
+
+
+local reco_fork = [
+  g.pipeline([
+              // wcls_simchannel_sink[n],
+              bagger[n],
+              sn_pipes[n],
+              // hio_orig[n],
+              // nf_pipes[n],
+              // rio_nf[n],
+              sp_pipes[n],
+              hio_sp[n],
+
+              // dnn_roi_finding[n],
+
+              dnnroi(tools.anodes[n], ts, output_scale=1.2),
+
+              hio_dnn[n],
+              // rio_sp[n],
+              g.pnode({ type: 'DumpFrames', name: 'reco_fork%d'%n }, nin=1, nout=0),
+              // perapa_img_pipelines[n],
+             ],
+             'reco_fork%d' % n)
+  for n in anode_iota
+];
+
+local truth_fork = [
+  g.pipeline([
+               deposplats[n],
+               hio_truth[n],
+               g.pnode({ type: 'DumpFrames', name: 'truth_fork%d'%n  }, nin=1, nout=0)
+             ],
+             'truth_fork%d' % n)
+  for n in anode_iota
+];
+
+local depo_fanout = [g.pnode({
+    type:'DepoFanout',
+    name:'depo_fanout-%d'%n,
+    data:{
+        multiplicity:2,
+        tags: [],
+    }}, nin=1, nout=2) for n in anode_iota];
+local frame_fanin = [g.pnode({
+    type: 'FrameFanin',
+    name: 'frame_fanin-%d'%n,
+    data: {
+        multiplicity: 2, 
+        tags: [],
+    }}, nin=2, nout=1) for n in anode_iota];
+
+local frame_sink = g.pnode({ type: 'DumpFrames' }, nin=1, nout=0);
+
+local multipass = [g.intern(innodes=[depo_fanout[n]], centernodes=[truth_fork[n], reco_fork[n]], outnodes=[],
+                     edges = [
+                       g.edge(depo_fanout[n], truth_fork[n],  0, 0),
+                       g.edge(depo_fanout[n], reco_fork[n],   1, 0)]) for n in anode_iota];
+
+// local multipass = [reco_fork[n] for n in anode_iota];
+
+local outtags = ['orig%d' % n for n in anode_iota];
+// local bi_manifold = f.fanpipe('DepoFanout', multipass, 'FrameFanin', 'sn_mag_nf', outtags);
+
+
+local depo_fanout_1st = g.pnode({
+    type:'DepoFanout',
+    name:'depo_fanout_1st',
+    data:{
+        multiplicity:nanodes,
+        tags: [],
+    }}, nin=1, nout=nanodes);
+local bi_manifold = g.intern(innodes=[depo_fanout_1st], centernodes=multipass, outnodes=[],
+                      edges = [
+                        g.edge(depo_fanout_1st, multipass[n],  n, 0) for n in anode_iota
+                      ],
+);
+
+local retagger = g.pnode({
+  type: 'Retagger',
+  data: {
+    // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+    tag_rules: [{
+      // Retagger also handles "frame" and "trace" like fanin/fanout
+      // merge separately all traces like gaussN to gauss.
+      frame: {
+        '.*': 'orig',
+      },
+      merge: {
+        'orig\\d': 'daq',
+      },
+    }],
+  },
+}, nin=1, nout=1);
+
+//local frameio = io.numpy.frames(output);
+local sink = sim.frame_sink;
+
+// g4 sim as input
+local graph = g.intern(innodes=[wcls_input.depos], centernodes=[drifter, depo_fanout_1st]+multipass, outnodes=[],
+                      edges = 
+                      [
+                        g.edge(wcls_input.depos, drifter, 0, 0),
+                        g.edge(drifter, depo_fanout_1st, 0, 0),
+                      ] +
+                      [g.edge(depo_fanout_1st, multipass[n],  n, 0) for n in anode_iota],
+                      );
+local app = {
+  type: 'Pgrapher',
+  data: {
+    edges: g.edges(graph),
+  },
+};
+g.uses(graph) + [app]

--- a/dunereco/DUNEWireCell/protodunevd/wct-sim-check-dnnsp.jsonnet
+++ b/dunereco/DUNEWireCell/protodunevd/wct-sim-check-dnnsp.jsonnet
@@ -134,16 +134,16 @@ local bagger = sim.make_bagger();
 local sn_pipes = sim.splusn_pipelines;
 // local analog_pipes = sim.analog_pipelines;
 
-// local perfect = import 'pgrapher/experiment/protodunevd/chndb-base.jsonnet';
-// local chndb = [{
-//   type: 'OmniChannelNoiseDB',
-//   name: 'ocndbperfect%d' % n,
-//   data: perfect(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
-//   uses: [tools.anodes[n], tools.field, tools.dft],
-// } for n in anode_iota];
-// 
-// local nf_maker = import 'pgrapher/experiment/protodunevd/nf.jsonnet';
-// local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in std.range(0, std.length(tools.anodes) - 1)];
+local perfect = import 'pgrapher/experiment/protodunevd/chndb-base.jsonnet';
+local chndb = [{
+  type: 'OmniChannelNoiseDB',
+  name: 'ocndbperfect%d' % n,
+  data: perfect(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
+  uses: [tools.anodes[n], tools.field, tools.dft],
+} for n in anode_iota];
+
+local nf_maker = import 'pgrapher/experiment/protodunevd/nf.jsonnet';
+local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in std.range(0, std.length(tools.anodes) - 1)];
 
 local sp_override = if fcl_params.use_dnnroi then
 {
@@ -154,6 +154,8 @@ local sp_override = if fcl_params.use_dnnroi then
     mp_tick_resolution: 4,
 } else {
     sparse: true,
+    use_multi_plane_protection: true,
+    mp_tick_resolution: 4,
 };
 
 local sp_maker = import 'pgrapher/experiment/protodunevd/sp.jsonnet';
@@ -201,8 +203,9 @@ local dnnroi = import 'pgrapher/experiment/protodunevd/dnnroi.jsonnet';
 local parallel_pipes = [
   g.pipeline([
                sn_pipes[n],
-               magnifyio.orig_pipe[n],
-               // nf_pipes[n],
+               // magnifyio.orig_pipe[n],
+               nf_pipes[n],
+               magnifyio.raw_pipe[n],
                sp_pipes[n],
                // magnifyio.decon_pipe[n],
                magnifyio.debug_pipe[n],

--- a/dunereco/DUNEWireCell/protodunevd/wct-sim-fans.jsonnet
+++ b/dunereco/DUNEWireCell/protodunevd/wct-sim-fans.jsonnet
@@ -64,7 +64,7 @@ local sp_maker = import 'pgrapher/experiment/protodunevd/sp.jsonnet';
 local sp_override = {
     sparse: false,
     use_roi_debug_mode: false,
-    use_multi_plane_protection: false,
+    use_multi_plane_protection: true,
     mp_tick_resolution: 4,
 };
 local sp = sp_maker(params, tools, sp_override);

--- a/dunereco/DUNEWireCell/protodunevd/wct-sim-sigproc-fans.jsonnet
+++ b/dunereco/DUNEWireCell/protodunevd/wct-sim-sigproc-fans.jsonnet
@@ -64,7 +64,7 @@ local sp_maker = import 'pgrapher/experiment/protodunevd/sp.jsonnet';
 local sp_override = {
     sparse: false,
     use_roi_debug_mode: false,
-    use_multi_plane_protection: false,
+    use_multi_plane_protection: true,
     mp_tick_resolution: 4,
 };
 local sp = sp_maker(params, tools, sp_override);

--- a/dunereco/DUNEWireCell/wirecell_dune.fcl
+++ b/dunereco/DUNEWireCell/wirecell_dune.fcl
@@ -305,6 +305,27 @@ wirecell_protodunevd_sim_deposplat:
     }
 }
 
+wirecell_pdhd_sim_deposplat:
+{
+    module_type : WireCellToolkit
+    wcls_main: {
+        tool_type: WCLS
+        apps: ["Pgrapher"]
+        plugins: ["WireCellPgraph", "WireCellGen","WireCellSio","WireCellSigProc","WireCellRoot","WireCellLarsoft","WireCellHio","WireCellTbb","WireCellImg","WireCellPytorch"]
+        configs: ["pgrapher/experiment/pdhd/wcls-sim-drift-deposplat.jsonnet"]
+        inputers: ["wclsSimDepoSource:"]
+        outputers: [
+            // "wclsSimChannelSink:postdrift",
+            // "wclsFrameSaver:simdigits"
+        ]
+        params: {
+        }
+	structs: {
+	}
+    }
+}
+
+
 
 dune10kt_mc_nfsp:
 {


### PR DESCRIPTION
lar -n1 -c prod_cosmics_1GeV_protodunehd.fcl -o gen.root
lar -n1 -c standard_g4_protodunehd_stage1.fcl gen.root -o g4a.root
lar -n1 -c standard_g4_protodunehd_stage2.fcl g4a.root -o g4b.root

cp -r /dune/data/users/wgu/dune10kt_1x2x6/wire-cell-cfg/ts-model .
lar -n1 -c pdhd_wirecell_sim_deposplat.fcl g4b.root

One should see hdf5 output files such as: g4-tru-0.h5 (truth label) & g4-rec-0.h5 (sigproc products)