### PR TITLE
revert to previous version until new version wirecell

### DIFF
--- a/dunereco/DUNEWireCell/common/tools.jsonnet
+++ b/dunereco/DUNEWireCell/common/tools.jsonnet
@@ -51,7 +51,8 @@ function(params)
     },
 
     perchanresp : {
-        type: "ParamsPerChannelResponse",
+        // type: "ParamsPerChannelResponse",
+        type: "PerChannelResponse",
         data: {
             filename: params.files.chresp,
         }


### PR DESCRIPTION
_ParamsPerChannelResponse_ is designed to integrate the per-channel correction of electronics calibration. However, it will only be available in the next version of wriecell toolkit. So let's revert it.