### PR TITLE
Adding Ereco methods forcing the use of range and mcs calculations

### DIFF
--- a/dunereco/FDSensOpt/energyreco.fcl
+++ b/dunereco/FDSensOpt/energyreco.fcl
@@ -44,6 +44,18 @@ dunefd_nuenergyreco_pandora_numu:
     HitToSpacePointLabel:   "pandora"
 }
 
+dunefd_nuenergyreco_pandora_numu_range:
+{
+    @table::dunefd_nuenergyreco_pandora_numu
+    LongestTrackMethod: 1
+}
+
+dunefd_nuenergyreco_pandora_numu_mcs:
+{
+    @table::dunefd_nuenergyreco_pandora_numu
+    LongestTrackMethod: 2
+}
+
 dunefd_nuenergyreco_pandora_nue:
 {
     @table::dunefd_nuenergyreco_pandora_numu


### PR DESCRIPTION
Adding reco methods to specifically use the MCS and range determinations of the muon momentum.