### PR TITLE
fix disambiguation by looking at the tested side of APA

### DIFF
--- a/dunereco/HitFinderDUNE/DisambigFromSpacePoints_module.cc
+++ b/dunereco/HitFinderDUNE/DisambigFromSpacePoints_module.cc
@@ -325,7 +325,7 @@ namespace dune {
                     {
                         if (cwids[w].TPC != spTpc) { continue; } // not that side of APA
 
-                        float sp_wire = fWireReadoutGeom->Plane(id).WireCoordinate(sp->position());
+                        float sp_wire = fWireReadoutGeom->Plane(cwids[w]).WireCoordinate(sp->position());
                         float dw = std::fabs(sp_wire - cwids[w].Wire);
                         if (dw < max_dw)
                         {


### PR DESCRIPTION
This PR fixes  bug in the upgrade of DisambigFromSpacePoints_module.cc to LArSoft v10 with the refactored geometry interface.  The issue is that "id" is a constant WireID in the loop over cwids.  We need to compute the WireCoordinate in the plane we are testing, which may be on the opposite side of the APA from the one that is in the un-disambiguated recob::Hit from which "id" comes.  So replacing "id" with "cwids[w]" makes the WireCoordinate calculation happen in the right TPC.