### PR TITLE
Hit-based direction reconstruction

### DIFF
--- a/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/CMakeLists.txt
+++ b/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/CMakeLists.txt
@@ -30,9 +30,12 @@ art_make( BASENAME_ONLY
   art::Utilities canvas::canvas
   fhiclcpp::fhiclcpp
   messagefacility::MF_MessageLogger
-  ROOT::EG
   cetlib::cetlib cetlib_except::cetlib_except
   ROOT::TMVA
+  ROOT_EG
+  ROOT_BASIC_LIB_LIST
+  ROOT::Minuit
+  ROOT::Minuit2
   )
 
 

--- a/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/CMakeLists.txt
+++ b/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/CMakeLists.txt
@@ -32,8 +32,7 @@ art_make( BASENAME_ONLY
   messagefacility::MF_MessageLogger
   cetlib::cetlib cetlib_except::cetlib_except
   ROOT::TMVA
-  ROOT_EG
-  ROOT_BASIC_LIB_LIST
+  ROOT::EG
   ROOT::Minuit
   ROOT::Minuit2
   )

--- a/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.h
+++ b/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.h
@@ -51,14 +51,6 @@ class CalorimetricDirectionFitter {
         double _pU = 0, _pV = 0, _pW = 0;
         double _pxU = 0, _pxV = 0, _pxW = 0;
         int _nhitsU = 0, _nhitsV = 0, _nhitsW = 0;
-        const std::vector<double> _calib_consts = {
-            1.5e-5, //pxU
-            1.5e-5, //pxV
-            1e-5,   //pxW
-            1.3e-5, //pU
-            1.3e-5, //pV
-            1e-5    //pW
-        }; //TODO: Not ideal at all... I guess these could be obtained from calculations
 };
 
 class NeutrinoAngularRecoAlg 

--- a/dunereco/FDSensOpt/angularreco.fcl
+++ b/dunereco/FDSensOpt/angularreco.fcl
@@ -38,7 +38,7 @@ dunefd_nuangularreco_pandora_numu:
     @table::dunefd_nuangularreco_pmtrack
     RecoMethod:             1
     WireLabel:              "wclsmcnfsp:gauss"
-    HitLabel:               "gaushit"
+    HitLabel:               "hitfd"
     TrackLabel:             "pandoraTrack"
     ShowerLabel:            "pandoraShower"
     TrackToHitLabel:        "pandoraTrack"
@@ -67,6 +67,12 @@ dunefd_nuangularreco_pandora_numu_allpfps:
 {
     @table::dunefd_nuangularreco_pandora_numu
     RecoMethod: 4
+}
+
+dunefd_nuangularreco_pandora_hits:
+{
+    @table::dunefd_nuangularreco_pandora_numu
+    RecoMethod: 5
 }
 
 


### PR DESCRIPTION
Implements a new direction reconstruction method based on the 2D hits.
More details can be found in the following presentation -> https://indico.fnal.gov/event/66461/contributions/301180/attachments/182621/250784/Direction%20reconstruction%20for%20atmospheric%20neutrinos%20UPDATE.pdf