### PR TITLE
First attempt Pandora configuration for reconstructing neutrinos in ProtoDUNE-HD

### DIFF
--- a/dunereco/DUNEPandora/pandoramodules_dune.fcl
+++ b/dunereco/DUNEPandora/pandoramodules_dune.fcl
@@ -65,6 +65,9 @@ protodune_pandora.ShouldPerformSliceId:                             true
 protodunehd_pandora:                                                @local::protodune_pandora
 protodunehd_pandora.ConfigFile:                                     "PandoraSettings_Master_ProtoDUNE_HD_TwoView_APA1.xml"
 
+protodunehd_neutrino_pandora:                                       @local::protodunehd_pandora
+protodunehd_neutrino_pandora.ConfigFile:                            "PandoraSettings_Master_ProtoDUNE_HD_Neutrino.xml"
+
 #----ProtoDUNE DP----
 protodune_dp_pandora:                                               @local::dune_pandora
 protodune_dp_pandora.ConfigFile:                                    "PandoraSettings_Master_ProtoDUNE_DP.xml"

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD_Neutrino.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD_Neutrino.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>true</IsMonitoringEnabled>
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 

--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD_Neutrino.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD_Neutrino.xml
@@ -1,0 +1,55 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>true</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArPreProcessing">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+    <algorithm type = "LArVisualMonitoring">
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</CaloHitListNames>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+
+    <algorithm type = "LArDLMaster">
+        <!--<CRSettingsFile>PandoraSettings_Cosmic_DUNEFD.xml</CRSettingsFile>-->
+        <CRSettingsFile>PandoraSettings_Cosmic_ProtoDUNE_HD_TwoView_APA1.xml</CRSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_DUNEFD.xml</NuSettingsFile>
+        <SlicingSettingsFile>PandoraSettings_Slicing_ProtoDUNE_HD_TwoView_APA1.xml</SlicingSettingsFile>
+        <StitchingTools>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>false</ThreeDStitchingMode></tool>
+        </StitchingTools>
+        <CosmicRayTaggingTools>
+            <!-- <tool type = "LArCosmicRayTagging"/> -->
+            <tool type = "LArTestBeamCosmicRayTagging">
+                <TagTopEntering>true</TagTopEntering>
+                <TagTopToBottom>true</TagTopToBottom>
+                <TagIsOutOfTime>true</TagIsOutOfTime>
+                <TagInVetoedTPCs>true</TagInVetoedTPCs>
+                <!--<VetoedTPCs>2 6</VetoedTPCs>-->
+            </tool>
+        </CosmicRayTaggingTools>
+        <SliceIdTools>
+            <tool type = "LArSimpleNeutrinoId"/>
+        </SliceIdTools>
+        <InputHitListName>CaloHitList2D</InputHitListName>
+        <InputMCParticleListName>Input</InputMCParticleListName>
+        <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
+        <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
+        <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
+        <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
+        <VisualizeOverallRecoStatus>true</VisualizeOverallRecoStatus>
+    </algorithm>
+
+    <algorithm type = "LArVisualMonitoring">
+        <ShowCurrentPfos>true</ShowCurrentPfos>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+</pandora>


### PR DESCRIPTION
Adds a new Pandora master settings file for ProtoDUNE-HD that runs the Far Detector neutrino reconstruction in place of the standard test-beam reconstruction. Also added a protodunehd_neutrino_pandora label to use in .fcl files to avoid the user having to change the ConfigFile parameter themselves.