### PR TITLE
configuration for electronics gain

### DIFF
--- a/dunereco/DUNEWireCell/pdhd/params.jsonnet
+++ b/dunereco/DUNEWireCell/pdhd/params.jsonnet
@@ -106,7 +106,8 @@ base {
     elecs: [
       super.elec {
         // The FE amplifier gain in units of Voltage/Charge.
-        gain : 14.0*wc.mV/wc.fC,
+        // gain : 14.0*wc.mV/wc.fC,
+        gain : std.extVar("elecGain")*wc.mV/wc.fC,
 
         // The shaping (aka peaking) time of the amplifier shaper.
         shaping : 2.2*wc.us,
@@ -157,8 +158,10 @@ base {
 
         // Noise models for different FE amplifier gains
         // Note: set gain value accordingly in the field of elecs
-        noise: "protodunehd-noise-spectra-14mVfC-v1.json.bz2",
+        // noise: "protodunehd-noise-spectra-14mVfC-v1.json.bz2",
         // noise: "protodunehd-noise-spectra-7d8mVfC-v1.json.bz2",
+        noise: if $.elec.gain > 8*wc.mV/wc.fC then "protodunehd-noise-spectra-14mVfC-v1.json.bz2"
+               else "protodunehd-noise-spectra-7d8mVfC-v1.json.bz2",
 
 
         chresp: null,

--- a/dunereco/DUNEWireCell/wirecell_dune.fcl
+++ b/dunereco/DUNEWireCell/wirecell_dune.fcl
@@ -119,6 +119,7 @@ protodunespdata_wctsp:
 
 protodunehddata_wctsp: @local::protodunespdata_wctsp
 protodunehddata_wctsp.wcls_main.configs: ["pgrapher/experiment/pdhd/wcls-sp.jsonnet"]
+protodunehddata_wctsp.wcls_main.structs.elecGain:    14 # 14 or 7.8 mV/fC
 
 protodunehd_nfsp:
 {
@@ -136,6 +137,9 @@ protodunehd_nfsp:
             reality: "data" # vs. "sim"
             epoch: "after"
             signal_output_form: "sparse"
+        }
+        structs: {
+            elecGain:    14 # 14 or 7.8 mV/fC
         }
     }
 }
@@ -158,6 +162,7 @@ protodunehd_nf : {
       }
       structs: {
          clock_speed: @local::protodunehd_services.DetectorClocksService.ClockSpeedTPC
+         elecGain:    14 # 14 or 7.8 mV/fC
       }
 
    }
@@ -182,6 +187,7 @@ protodunehd_sp:
         }
         structs: {
            clock_speed: @local::protodunehd_services.DetectorClocksService.ClockSpeedTPC
+           elecGain:    14 # 14 or 7.8 mV/fC
         }
 
     }
@@ -204,6 +210,7 @@ protodunehd_dnnsp:
         }
         structs: {
            clock_speed: @local::protodunehd_services.DetectorClocksService.ClockSpeedTPC
+           elecGain:    14 # 14 or 7.8 mV/fC
         }
 
     }
@@ -251,6 +258,7 @@ wirecell_protodunespmc:
 
 wirecell_protodunehdmc: @local::wirecell_protodunespmc
 wirecell_protodunehdmc.wcls_main.configs: ["pgrapher/experiment/pdhd/wcls-sim-drift-simchannel-priorSCE.jsonnet"]
+wirecell_protodunehdmc.wcls_main.structs.elecGain:    14 # 14 or 7.8 mV/fC
 
 wirecell_dunevd_coldbox_mc:
 {
@@ -1852,6 +1860,9 @@ protodunehd_nfspimg : {
          signal_output_form: "dense"
          use_magnify: "false"
       }
+      structs: {
+         elecGain:    14 # 14 or 7.8 mV/fC
+      }
    }
 }
 
@@ -1870,6 +1881,9 @@ protodunehd_img : {
          charge_input_label: "wclsdatahd:gauss"
          wiener_input_label: "wclsdatahd:wiener"
          reality: "data"
+      }
+      structs: {
+         elecGain:    14 # 14 or 7.8 mV/fC
       }
    }
 }


### PR DESCRIPTION
This PR allows a different electronics gain for data & simulation.

Some validations are done with PDHD's cosmic-ray simulation:
![image](https://github.com/user-attachments/assets/ebbd21e4-997b-4ad9-ace3-2c181e7eee4f)

![image](https://github.com/user-attachments/assets/843d4ebc-345d-4b04-951c-65d407d3b798)

![image](https://github.com/user-attachments/assets/34536aab-0d5d-4031-b952-7891d552bc72)
