### PR TITLE
131: change adc resolution to 14 bits

### DIFF
--- a/dunereco/DUNEWireCell/common/params.jsonnet
+++ b/dunereco/DUNEWireCell/common/params.jsonnet
@@ -117,7 +117,7 @@ local wc = import "wirecell.jsonnet";
     // Parameters having to do with the front end electronics
     elec : {
         // The FE amplifier gain in units of Voltage/Charge.
-        gain : 14*wc.mV/wc.fC, 
+        gain : 7.8*wc.mV/wc.fC, // used to be 14 mV/fC
 
         // The shaping (aka peaking) time of the amplifier shaper.
         shaping : 2.0*wc.us,

--- a/dunereco/DUNEWireCell/common/params.jsonnet
+++ b/dunereco/DUNEWireCell/common/params.jsonnet
@@ -107,7 +107,7 @@ local wc = import "wirecell.jsonnet";
         baselines: [900*wc.millivolt,900*wc.millivolt,200*wc.millivolt],
 
         // The resolution (bits) of the ADC
-        resolution: 12,
+        resolution: 14, // used to be 12 bits
 
         // The voltage range as [min,max] of the ADC, eg min voltage
         // counts 0 ADC, max counts 2^resolution-1.
@@ -117,7 +117,7 @@ local wc = import "wirecell.jsonnet";
     // Parameters having to do with the front end electronics
     elec : {
         // The FE amplifier gain in units of Voltage/Charge.
-        gain : 14.0*wc.mV/wc.fC,
+        gain : 14*wc.mV/wc.fC, 
 
         // The shaping (aka peaking) time of the amplifier shaper.
         shaping : 2.0*wc.us,

--- a/dunereco/DUNEWireCell/dune-vd/params.jsonnet
+++ b/dunereco/DUNEWireCell/dune-vd/params.jsonnet
@@ -50,7 +50,7 @@ function(params) base {
         
         // Set 0 for now
         //baselines: [0*wc.millivolt, 0*wc.millivolt, 0*wc.millivolt],
-        //resolution: 12,
+        //resolution: 14,
         //fullscale: [0.2*wc.volt, 1.6*wc.volt],
 
         // Copied from pdsp. induction plane: 2350 ADC, collection plane: 900 ADC

--- a/dunereco/DUNEWireCell/dune-vd/wcls-sim-drift-simchannel-2view.json
+++ b/dunereco/DUNEWireCell/dune-vd/wcls-sim-drift-simchannel-2view.json
@@ -1263,7 +1263,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer0",
       "type": "Digitizer"
@@ -1336,7 +1336,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer1",
       "type": "Digitizer"
@@ -1409,7 +1409,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer2",
       "type": "Digitizer"
@@ -1482,7 +1482,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer3",
       "type": "Digitizer"
@@ -1555,7 +1555,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer4",
       "type": "Digitizer"
@@ -1628,7 +1628,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer5",
       "type": "Digitizer"
@@ -1701,7 +1701,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer6",
       "type": "Digitizer"
@@ -1774,7 +1774,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer7",
       "type": "Digitizer"
@@ -1847,7 +1847,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer8",
       "type": "Digitizer"
@@ -1920,7 +1920,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer9",
       "type": "Digitizer"
@@ -1993,7 +1993,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer10",
       "type": "Digitizer"
@@ -2066,7 +2066,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer11",
       "type": "Digitizer"
@@ -2139,7 +2139,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer12",
       "type": "Digitizer"
@@ -2212,7 +2212,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer13",
       "type": "Digitizer"
@@ -2285,7 +2285,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer14",
       "type": "Digitizer"
@@ -2358,7 +2358,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer15",
       "type": "Digitizer"
@@ -2431,7 +2431,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer16",
       "type": "Digitizer"
@@ -2504,7 +2504,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer17",
       "type": "Digitizer"
@@ -2577,7 +2577,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer18",
       "type": "Digitizer"
@@ -2650,7 +2650,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer19",
       "type": "Digitizer"
@@ -2723,7 +2723,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer20",
       "type": "Digitizer"
@@ -2796,7 +2796,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer21",
       "type": "Digitizer"
@@ -2869,7 +2869,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer22",
       "type": "Digitizer"
@@ -2942,7 +2942,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer23",
       "type": "Digitizer"
@@ -3015,7 +3015,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer24",
       "type": "Digitizer"
@@ -3088,7 +3088,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer25",
       "type": "Digitizer"
@@ -3161,7 +3161,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer26",
       "type": "Digitizer"
@@ -3234,7 +3234,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer27",
       "type": "Digitizer"
@@ -3307,7 +3307,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer28",
       "type": "Digitizer"
@@ -3380,7 +3380,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer29",
       "type": "Digitizer"
@@ -3453,7 +3453,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer30",
       "type": "Digitizer"
@@ -3526,7 +3526,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer31",
       "type": "Digitizer"
@@ -3599,7 +3599,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer32",
       "type": "Digitizer"
@@ -3672,7 +3672,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer33",
       "type": "Digitizer"
@@ -3745,7 +3745,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer34",
       "type": "Digitizer"
@@ -3818,7 +3818,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer35",
       "type": "Digitizer"

--- a/dunereco/DUNEWireCell/dune-vd/wcls-sim-drift-simchannel-3view.json
+++ b/dunereco/DUNEWireCell/dune-vd/wcls-sim-drift-simchannel-3view.json
@@ -1263,7 +1263,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer0",
       "type": "Digitizer"
@@ -1336,7 +1336,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer1",
       "type": "Digitizer"
@@ -1409,7 +1409,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer2",
       "type": "Digitizer"
@@ -1482,7 +1482,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer3",
       "type": "Digitizer"
@@ -1555,7 +1555,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer4",
       "type": "Digitizer"
@@ -1628,7 +1628,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer5",
       "type": "Digitizer"
@@ -1701,7 +1701,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer6",
       "type": "Digitizer"
@@ -1774,7 +1774,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer7",
       "type": "Digitizer"
@@ -1847,7 +1847,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer8",
       "type": "Digitizer"
@@ -1920,7 +1920,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer9",
       "type": "Digitizer"
@@ -1993,7 +1993,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer10",
       "type": "Digitizer"
@@ -2066,7 +2066,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer11",
       "type": "Digitizer"
@@ -2139,7 +2139,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer12",
       "type": "Digitizer"
@@ -2212,7 +2212,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer13",
       "type": "Digitizer"
@@ -2285,7 +2285,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer14",
       "type": "Digitizer"
@@ -2358,7 +2358,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer15",
       "type": "Digitizer"
@@ -2431,7 +2431,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer16",
       "type": "Digitizer"
@@ -2504,7 +2504,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer17",
       "type": "Digitizer"
@@ -2577,7 +2577,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer18",
       "type": "Digitizer"
@@ -2650,7 +2650,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer19",
       "type": "Digitizer"
@@ -2723,7 +2723,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer20",
       "type": "Digitizer"
@@ -2796,7 +2796,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer21",
       "type": "Digitizer"
@@ -2869,7 +2869,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer22",
       "type": "Digitizer"
@@ -2942,7 +2942,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer23",
       "type": "Digitizer"
@@ -3015,7 +3015,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer24",
       "type": "Digitizer"
@@ -3088,7 +3088,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer25",
       "type": "Digitizer"
@@ -3161,7 +3161,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer26",
       "type": "Digitizer"
@@ -3234,7 +3234,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer27",
       "type": "Digitizer"
@@ -3307,7 +3307,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer28",
       "type": "Digitizer"
@@ -3380,7 +3380,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer29",
       "type": "Digitizer"
@@ -3453,7 +3453,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer30",
       "type": "Digitizer"
@@ -3526,7 +3526,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer31",
       "type": "Digitizer"
@@ -3599,7 +3599,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer32",
       "type": "Digitizer"
@@ -3672,7 +3672,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer33",
       "type": "Digitizer"
@@ -3745,7 +3745,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer34",
       "type": "Digitizer"
@@ -3818,7 +3818,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer35",
       "type": "Digitizer"

--- a/dunereco/DUNEWireCell/dune-vd/wcls-sim-drift-simchannel-3view30deg.json
+++ b/dunereco/DUNEWireCell/dune-vd/wcls-sim-drift-simchannel-3view30deg.json
@@ -1263,7 +1263,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer0",
       "type": "Digitizer"
@@ -1336,7 +1336,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer1",
       "type": "Digitizer"
@@ -1409,7 +1409,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer2",
       "type": "Digitizer"
@@ -1482,7 +1482,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer3",
       "type": "Digitizer"
@@ -1555,7 +1555,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer4",
       "type": "Digitizer"
@@ -1628,7 +1628,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer5",
       "type": "Digitizer"
@@ -1701,7 +1701,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer6",
       "type": "Digitizer"
@@ -1774,7 +1774,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer7",
       "type": "Digitizer"
@@ -1847,7 +1847,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer8",
       "type": "Digitizer"
@@ -1920,7 +1920,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer9",
       "type": "Digitizer"
@@ -1993,7 +1993,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer10",
       "type": "Digitizer"
@@ -2066,7 +2066,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer11",
       "type": "Digitizer"
@@ -2139,7 +2139,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer12",
       "type": "Digitizer"
@@ -2212,7 +2212,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer13",
       "type": "Digitizer"
@@ -2285,7 +2285,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer14",
       "type": "Digitizer"
@@ -2358,7 +2358,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer15",
       "type": "Digitizer"
@@ -2431,7 +2431,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer16",
       "type": "Digitizer"
@@ -2504,7 +2504,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer17",
       "type": "Digitizer"
@@ -2577,7 +2577,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer18",
       "type": "Digitizer"
@@ -2650,7 +2650,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer19",
       "type": "Digitizer"
@@ -2723,7 +2723,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer20",
       "type": "Digitizer"
@@ -2796,7 +2796,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer21",
       "type": "Digitizer"
@@ -2869,7 +2869,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer22",
       "type": "Digitizer"
@@ -2942,7 +2942,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer23",
       "type": "Digitizer"
@@ -3015,7 +3015,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer24",
       "type": "Digitizer"
@@ -3088,7 +3088,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer25",
       "type": "Digitizer"
@@ -3161,7 +3161,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer26",
       "type": "Digitizer"
@@ -3234,7 +3234,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer27",
       "type": "Digitizer"
@@ -3307,7 +3307,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer28",
       "type": "Digitizer"
@@ -3380,7 +3380,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer29",
       "type": "Digitizer"
@@ -3453,7 +3453,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer30",
       "type": "Digitizer"
@@ -3526,7 +3526,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer31",
       "type": "Digitizer"
@@ -3599,7 +3599,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer32",
       "type": "Digitizer"
@@ -3672,7 +3672,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer33",
       "type": "Digitizer"
@@ -3745,7 +3745,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer34",
       "type": "Digitizer"
@@ -3818,7 +3818,7 @@
             1.9999999999999999e-06
          ],
          "gain": 1,
-         "resolution": 12
+         "resolution": 14
       },
       "name": "digitizer35",
       "type": "Digitizer"

--- a/dunereco/DUNEWireCell/wirecell_dune.fcl
+++ b/dunereco/DUNEWireCell/wirecell_dune.fcl
@@ -52,6 +52,7 @@ protodunespdata_nfsp:
         }
 
         structs: {
+            Nbit: 12 # still 12 in sp times
             # Define wire filter for signal processing (sp-filters.jsonnet)
             # wf('Wire_col', { sigma: 1.0 / wc.sqrtpi * std.extVar('wire_col_nsigma') }),
             wire_col_nsigma: 10.0
@@ -110,6 +111,7 @@ protodunespdata_wctsp:
         }
 
         structs: {
+            Nbit: 12 # still 12 in sp times
             # Define wire filter for signal processing (sp-filters.jsonnet)
             # wf('Wire_col', { sigma: 1.0 / wc.sqrtpi * std.extVar('wire_col_nsigma') }),
             wire_col_nsigma: 10.0
@@ -119,7 +121,8 @@ protodunespdata_wctsp:
 
 protodunehddata_wctsp: @local::protodunespdata_wctsp
 protodunehddata_wctsp.wcls_main.configs: ["pgrapher/experiment/pdhd/wcls-sp.jsonnet"]
-protodunehddata_wctsp.wcls_main.structs.elecGain:    14 # 14 or 7.8 mV/fC
+protodunehddata_wctsp.wcls_main.structs.elecGain:    14 # 14 or 7.8 mV/fC (7.8 from July '24 onwards). Consider accessing through database?
+protodunehddata_wctsp.wcls_main.structs.Nbit: 14 
 
 protodunehd_nfsp:
 {
@@ -139,6 +142,7 @@ protodunehd_nfsp:
             signal_output_form: "sparse"
         }
         structs: {
+            Nbit: 14 
             elecGain:    14 # 14 or 7.8 mV/fC
         }
     }
@@ -161,6 +165,7 @@ protodunehd_nf : {
          signal_output_form: "sparse"
       }
       structs: {
+         Nbit: 14 
          clock_speed: @local::protodunehd_services.DetectorClocksService.ClockSpeedTPC
          elecGain:    14 # 14 or 7.8 mV/fC
       }
@@ -186,6 +191,7 @@ protodunehd_sp:
             signal_output_form: "sparse"
         }
         structs: {
+           Nbit: 14 
            clock_speed: @local::protodunehd_services.DetectorClocksService.ClockSpeedTPC
            elecGain:    14 # 14 or 7.8 mV/fC
         }
@@ -209,6 +215,7 @@ protodunehd_dnnsp:
             signal_output_form: "dense" # "sparse"
         }
         structs: {
+           Nbit: 14 
            clock_speed: @local::protodunehd_services.DetectorClocksService.ClockSpeedTPC
            elecGain:    14 # 14 or 7.8 mV/fC
         }
@@ -244,6 +251,7 @@ wirecell_protodunespmc:
         params: {
         }
         structs: {
+            Nbit: 14 
             // Longitudinal diffusion constant [cm2/s]
             DL: 4.0
             // Transverse diffusion constant [cm2/s]
@@ -259,6 +267,7 @@ wirecell_protodunespmc:
 wirecell_protodunehdmc: @local::wirecell_protodunespmc
 wirecell_protodunehdmc.wcls_main.configs: ["pgrapher/experiment/pdhd/wcls-sim-drift-simchannel-priorSCE.jsonnet"]
 wirecell_protodunehdmc.wcls_main.structs.elecGain:    14 # 14 or 7.8 mV/fC
+wirecell_protodunehdmc.wcls_main.structs.Nbit: 14 
 
 wirecell_dunevd_coldbox_mc:
 {
@@ -280,13 +289,14 @@ wirecell_dunevd_coldbox_mc:
             active_cru: 'tde' // 'bde'
         }
 	structs: {
-           # number of time samples
-           nticks: @local::vdcb_crp1_top_services.DetectorPropertiesService.NumberTimeSamples
-	   lifetime: @local::vdcb_crp1_top_services.DetectorPropertiesService.Electronlifetime
-	   DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
-	   DT: @local::dunefd_largeantparameters.TransverseDiffusion
-           efield: @local::vdcb_crp1_top_services.DetectorPropertiesService.Efield[0] # kV/cm
-           temperature: @local::vdcb_services.DetectorPropertiesService.Temperature # K
+        Nbit: 14 
+        # number of time samples
+        nticks: @local::vdcb_crp1_top_services.DetectorPropertiesService.NumberTimeSamples
+        lifetime: @local::vdcb_crp1_top_services.DetectorPropertiesService.Electronlifetime
+        DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+        DT: @local::dunefd_largeantparameters.TransverseDiffusion
+        efield: @local::vdcb_crp1_top_services.DetectorPropertiesService.Efield[0] # kV/cm
+        temperature: @local::vdcb_services.DetectorPropertiesService.Temperature # K
 	}
     }
 }
@@ -308,14 +318,15 @@ wirecell_dunevd_coldboxcrp2_mc:
         ]
 
 	structs: {
-           # number of time samples
-           nticks: @local::vdcb_crp2_services.DetectorPropertiesService.NumberTimeSamples
-           clock_speed: @local::vdcb_crp2_services.DetectorClocksService.ClockSpeedTPC
-	   lifetime: @local::vdcb_crp2_services.DetectorPropertiesService.Electronlifetime
-	   DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
-	   DT: @local::dunefd_largeantparameters.TransverseDiffusion
-           efield: @local::vdcb_crp2_services.DetectorPropertiesService.Efield[0] # kV/cm
-           temperature: @local::vdcb_services.DetectorPropertiesService.Temperature # K
+        Nbit: 14 
+        # number of time samples
+        nticks: @local::vdcb_crp2_services.DetectorPropertiesService.NumberTimeSamples
+        clock_speed: @local::vdcb_crp2_services.DetectorClocksService.ClockSpeedTPC
+        lifetime: @local::vdcb_crp2_services.DetectorPropertiesService.Electronlifetime
+        DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+        DT: @local::dunefd_largeantparameters.TransverseDiffusion
+        efield: @local::vdcb_crp2_services.DetectorPropertiesService.Efield[0] # kV/cm
+        temperature: @local::vdcb_services.DetectorPropertiesService.Temperature # K
 	}
     }
 }
@@ -336,14 +347,15 @@ wirecell_dunevd_coldboxcrp4_mc:
         ]
 
 	structs: {
-           # number of time samples
-           nticks: @local::vdcb_crp4_services.DetectorPropertiesService.NumberTimeSamples
-           clock_speed: @local::vdcb_crp4_services.DetectorClocksService.ClockSpeedTPC
-	   lifetime: @local::vdcb_crp4_services.DetectorPropertiesService.Electronlifetime
-	   DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
-	   DT: @local::dunefd_largeantparameters.TransverseDiffusion
-           efield: @local::vdcb_crp4_services.DetectorPropertiesService.Efield[0] # kV/cm
-           temperature: @local::vdcb_services.DetectorPropertiesService.Temperature # K
+        Nbit: 14 
+        # number of time samples
+        nticks: @local::vdcb_crp4_services.DetectorPropertiesService.NumberTimeSamples
+        clock_speed: @local::vdcb_crp4_services.DetectorClocksService.ClockSpeedTPC
+        lifetime: @local::vdcb_crp4_services.DetectorPropertiesService.Electronlifetime
+        DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+        DT: @local::dunefd_largeantparameters.TransverseDiffusion
+        efield: @local::vdcb_crp4_services.DetectorPropertiesService.Efield[0] # kV/cm
+        temperature: @local::vdcb_services.DetectorPropertiesService.Temperature # K
 	}
     }
 }
@@ -373,6 +385,7 @@ wirecell_protodunevd_mc:
         params: {
         }
 	structs: {
+           Nbit: 14 
            nticks: @local::protodunevd_services.DetectorPropertiesService.NumberTimeSamples
            lifetime: @local::protodunevd_services.DetectorPropertiesService.Electronlifetime
            DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
@@ -407,12 +420,13 @@ wirecell_protodunevd_mc_splusn:
         params: {
         }
 	structs: {
-           nticks: @local::protodunevd_services.DetectorPropertiesService.NumberTimeSamples
-           lifetime: @local::protodunevd_services.DetectorPropertiesService.Electronlifetime
-           DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
-           DT: @local::dunefd_largeantparameters.TransverseDiffusion
-           efield: @local::protodunevd_services.DetectorPropertiesService.Efield[0] # kV/cm
-           temperature: @local::protodunevd_services.DetectorPropertiesService.Temperature # K
+        Nbit: 14 
+        nticks: @local::protodunevd_services.DetectorPropertiesService.NumberTimeSamples
+        lifetime: @local::protodunevd_services.DetectorPropertiesService.Electronlifetime
+        DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+        DT: @local::dunefd_largeantparameters.TransverseDiffusion
+        efield: @local::protodunevd_services.DetectorPropertiesService.Efield[0] # kV/cm
+        temperature: @local::protodunevd_services.DetectorPropertiesService.Temperature # K
 	}
     }
 }
@@ -434,12 +448,13 @@ wirecell_protodunevd_sim_deposplat:
         params: {
         }
 	structs: {
-           nticks: @local::protodunevd_services.DetectorPropertiesService.NumberTimeSamples
-           lifetime: @local::protodunevd_services.DetectorPropertiesService.Electronlifetime
-           DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
-           DT: @local::dunefd_largeantparameters.TransverseDiffusion
-           efield: @local::protodunevd_services.DetectorPropertiesService.Efield[0] # kV/cm
-           temperature: @local::protodunevd_services.DetectorPropertiesService.Temperature # K
+        Nbit: 14 
+        nticks: @local::protodunevd_services.DetectorPropertiesService.NumberTimeSamples
+        lifetime: @local::protodunevd_services.DetectorPropertiesService.Electronlifetime
+        DL: @local::dunefd_largeantparameters.LongitudinalDiffusion
+        DT: @local::dunefd_largeantparameters.TransverseDiffusion
+        efield: @local::protodunevd_services.DetectorPropertiesService.Efield[0] # kV/cm
+        temperature: @local::protodunevd_services.DetectorPropertiesService.Temperature # K
 	}
     }
 }
@@ -460,6 +475,7 @@ wirecell_pdhd_sim_deposplat:
         params: {
         }
 	structs: {
+        Nbit: 14
 	}
     }
 }
@@ -518,6 +534,9 @@ dune10kt_1x2x6_mc_nfsp:
             # Save output signal waveforms (recob::Wire) in "sparse" or "dense" form
             signal_output_form: "sparse"
         }
+        structs:{
+            Nbit: 14
+        }
     }
 }
 
@@ -567,6 +586,9 @@ dune10kt_1x2x2_mc_nfsp:
 
             # Save output signal waveforms (recob::Wire) in "sparse" or "dense" form
             signal_output_form: "sparse"
+        }
+        structs:{
+            Nbit: 14
         }
     }
 }
@@ -634,6 +656,7 @@ tpcrawdecoder_dunefd_horizdrift_1x2x6 : {
       params: {
       }
       structs: {
+          Nbit: 14
           # number of time samples
           #nticks: @local::dunefd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns]
@@ -675,6 +698,7 @@ dunefd_horizdrift_1x2x6_sim_nfsp : {
             engine: "TbbFlow"
         }
         structs: {
+          Nbit: 14
           # number of time samples
           #nticks: @local::dunefd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns]
@@ -722,6 +746,7 @@ tpcrawdecoder_dunefd_horizdrift_1x2x2 : {
       params: {
       }
       structs: {
+        Nbit: 14
         # Longitudinal diffusion constant [cm2/s]
         DL: 4.0
         # Transverse diffusion constant [cm2/s]
@@ -778,6 +803,7 @@ tpcrawdecoder_dunefd_vertdrift_2view : {
         files_noise: "dunevd10kt-1x6x6-2view-noise-spectra-v1.json.bz2"
       }
       structs: {
+        Nbit: 14
         # number of time samples
         nticks: @local::dunefdvd_detproperties.NumberTimeSamples
         # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -810,6 +836,7 @@ tpcrawdecoder_dunefd_vertdrift_3view: {
           files_noise: "dunevd10kt-1x6x6-3view-noise-spectra-v1.json.bz2"
         }
         structs: {
+          Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -840,6 +867,7 @@ tpcrawdecoder_dunefd_vertdrift_1x8x6_3view: {
           files_noise: "dunevd10kt-1x6x6-3view-noise-spectra-v1.json.bz2"
         }
         structs: {
+            Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -870,6 +898,7 @@ tpcrawdecoder_dunefd_vertdrift_1x8x14_3view: {
           files_noise: "dunevd10kt-1x6x6-3view-noise-spectra-v1.json.bz2"
         }
         structs: {
+            Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -901,6 +930,7 @@ tpcrawdecoder_dunefd_vertdrift_3view_30deg: {
           files_noise: "dunevd10kt-1x6x6-3view30deg-noise-spectra-v1.json.bz2"
         }
         structs: {
+            Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -931,6 +961,7 @@ tpcrawdecoder_dunefd_vertdrift_1x8x6_3view_30deg: {
           files_noise: "dunevd10kt-1x6x6-3view30deg-noise-spectra-v1.json.bz2"
         }
         structs: {
+            Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -1001,6 +1032,7 @@ tpcrawdecoder_iceberg_splusn : {
       params: {
       }
       structs: {
+        Nbit: 14
         # Longitudinal diffusion constant [cm2/s]
         DL: 4.0
         # Transverse diffusion constant [cm2/s]
@@ -1132,6 +1164,7 @@ dune10kt_dunefd_vertdrift_1x6x6_3view_data_nfsp : {
       }
       # ext-code, code
       structs : {
+            Nbit: 14
           # for nticks calculation in common/params.jsonnet: elec
           driftSpeed: 1.60563
           
@@ -1219,6 +1252,7 @@ dune10kt_dunefd_vertdrift_1x6x6_3view_30deg_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          Nbit: 14
           # for nticks calculation in common/params.jsonnet: elec
           driftSpeed: 1.60563
           
@@ -1306,6 +1340,8 @@ dune10kt_dunefd_vertdrift_1x8x6_3view_30deg_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          Nbit: 14
+          
           # for nticks calculation in common/params.jsonnet: elec
           driftSpeed: 1.60563
           
@@ -1396,6 +1432,8 @@ dune10kt_dunefd_vertdrift_1x8x6_3view_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          Nbit: 14
+
           # for nticks calculation in common/params.jsonnet: elec
           driftSpeed: 1.60563
           
@@ -1486,6 +1524,8 @@ dune10kt_dunefd_vertdrift_1x8x14_3view_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          Nbit: 14
+
           # for nticks calculation in common/params.jsonnet: elec
           driftSpeed: 1.60563
           
@@ -1554,6 +1594,7 @@ dune10kt_dunefd_vertdrift_1x8x14_3view_sim_nfsp : {
             process_crm: "full"
         }
         structs: {
+            Nbit: 14
             # number of time samples
             nticks: @local::dunefdvd_detproperties.NumberTimeSamples
             # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -1697,6 +1738,9 @@ dune_vd_coldbox_nfsp : {
 
          use_magnify: "false"
       }
+      structs: {
+         Nbit: 14
+      }
    }
 }
 
@@ -1719,6 +1763,7 @@ dune_vd_crp2_nfsp : {
          use_magnify: "false"
       }
       structs: {
+         Nbit: 14
          clock_speed: @local::vdcb_crp2_services.DetectorClocksService.ClockSpeedTPC
       }
 
@@ -1744,6 +1789,7 @@ dune_vd_crp4_nfsp : {
          use_magnify: "false"
       }
       structs: {
+         Nbit: 14
          clock_speed: @local::vdcb_crp4_services.DetectorClocksService.ClockSpeedTPC
       }
 
@@ -1770,6 +1816,7 @@ dune_vd_crp2_nf : {
          use_magnify: "false"
       }
       structs: {
+         Nbit: 14
          clock_speed: @local::vdcb_crp2_services.DetectorClocksService.ClockSpeedTPC
       }
 
@@ -1796,6 +1843,7 @@ dune_vd_crp2_sp : {
          use_magnify: "false"
       }
       structs: {
+         Nbit: 14
          clock_speed: @local::vdcb_crp2_services.DetectorClocksService.ClockSpeedTPC
       }
 
@@ -1820,6 +1868,9 @@ protodunevd_nfsp : {
          signal_output_form: "sparse"
          use_magnify: "false"
       }
+      structs: {
+        Nbit: 14
+      }
    }
 }
 
@@ -1839,6 +1890,9 @@ protodunevd_nfspimg : {
          reality: "data"
          signal_output_form: "dense"
          use_magnify: "false"
+      }
+      structs: {
+        Nbit: 14
       }
    }
 }
@@ -1861,6 +1915,7 @@ protodunehd_nfspimg : {
          use_magnify: "false"
       }
       structs: {
+         Nbit: 14
          elecGain:    14 # 14 or 7.8 mV/fC
       }
    }
@@ -1883,6 +1938,7 @@ protodunehd_img : {
          reality: "data"
       }
       structs: {
+          Nbit: 14
          elecGain:    14 # 14 or 7.8 mV/fC
       }
    }
@@ -1903,6 +1959,9 @@ protodunesp_img : {
          charge_input_label: "wclsdatasp:gauss"
          wiener_input_label: "wclsdatasp:wiener"
          reality: "data"
+      }
+      structs: {
+          Nbit: 12 # it was still 12 in sp
       }
    }
 }
@@ -1932,6 +1991,7 @@ dune10kt_horizdrift_sim_nfsp : {
             engine: "TbbFlow"
         }
         structs: {
+          Nbit: 14 
           # number of time samples
           nticks: @local::dunefd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns]

--- a/dunereco/DUNEWireCell/wirecell_dune.fcl
+++ b/dunereco/DUNEWireCell/wirecell_dune.fcl
@@ -657,6 +657,7 @@ tpcrawdecoder_dunefd_horizdrift_1x2x6 : {
       }
       structs: {
           Nbit: 14
+          elecGain: 7.8 # new default since July 2024
           # number of time samples
           #nticks: @local::dunefd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns]
@@ -698,6 +699,7 @@ dunefd_horizdrift_1x2x6_sim_nfsp : {
             engine: "TbbFlow"
         }
         structs: {
+          elecGain: 7.8 # new default since July 2024
           Nbit: 14
           # number of time samples
           #nticks: @local::dunefd_detproperties.NumberTimeSamples
@@ -746,6 +748,7 @@ tpcrawdecoder_dunefd_horizdrift_1x2x2 : {
       params: {
       }
       structs: {
+        elecGain: 7.8 # new default since July 2024
         Nbit: 14
         # Longitudinal diffusion constant [cm2/s]
         DL: 4.0
@@ -803,6 +806,7 @@ tpcrawdecoder_dunefd_vertdrift_2view : {
         files_noise: "dunevd10kt-1x6x6-2view-noise-spectra-v1.json.bz2"
       }
       structs: {
+        elecGain: 7.8 # new default since July 2024
         Nbit: 14
         # number of time samples
         nticks: @local::dunefdvd_detproperties.NumberTimeSamples
@@ -836,6 +840,7 @@ tpcrawdecoder_dunefd_vertdrift_3view: {
           files_noise: "dunevd10kt-1x6x6-3view-noise-spectra-v1.json.bz2"
         }
         structs: {
+          elecGain: 7.8 # new default since July 2024
           Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
@@ -898,7 +903,8 @@ tpcrawdecoder_dunefd_vertdrift_1x8x14_3view: {
           files_noise: "dunevd10kt-1x6x6-3view-noise-spectra-v1.json.bz2"
         }
         structs: {
-            Nbit: 14
+          elecGain: 7.8 # new default since July 2024
+          Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -930,7 +936,8 @@ tpcrawdecoder_dunefd_vertdrift_3view_30deg: {
           files_noise: "dunevd10kt-1x6x6-3view30deg-noise-spectra-v1.json.bz2"
         }
         structs: {
-            Nbit: 14
+          elecGain: 7.8 # new default since July 2024
+          Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -961,7 +968,8 @@ tpcrawdecoder_dunefd_vertdrift_1x8x6_3view_30deg: {
           files_noise: "dunevd10kt-1x6x6-3view30deg-noise-spectra-v1.json.bz2"
         }
         structs: {
-            Nbit: 14
+          elecGain: 7.8 # new default since July 2024
+          Nbit: 14
           # number of time samples
           nticks: @local::dunefdvd_detproperties.NumberTimeSamples
           # Longitudinal diffusion constant [cm2/ns] 4.0e-9
@@ -1164,7 +1172,8 @@ dune10kt_dunefd_vertdrift_1x6x6_3view_data_nfsp : {
       }
       # ext-code, code
       structs : {
-            Nbit: 14
+          elecGain: 7.8 # new default since July 2024
+          Nbit: 14
           # for nticks calculation in common/params.jsonnet: elec
           driftSpeed: 1.60563
           
@@ -1252,6 +1261,7 @@ dune10kt_dunefd_vertdrift_1x6x6_3view_30deg_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          elecGain: 7.8 # new default since July 2024
           Nbit: 14
           # for nticks calculation in common/params.jsonnet: elec
           driftSpeed: 1.60563
@@ -1340,6 +1350,7 @@ dune10kt_dunefd_vertdrift_1x8x6_3view_30deg_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          elecGain: 7.8 # new default since July 2024
           Nbit: 14
           
           # for nticks calculation in common/params.jsonnet: elec
@@ -1432,6 +1443,7 @@ dune10kt_dunefd_vertdrift_1x8x6_3view_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          elecGain: 7.8 # new default since July 2024
           Nbit: 14
 
           # for nticks calculation in common/params.jsonnet: elec
@@ -1524,6 +1536,7 @@ dune10kt_dunefd_vertdrift_1x8x14_3view_data_nfsp : {
       }
       # ext-code, code
       structs : {
+          elecGain: 7.8 # new default since July 2024
           Nbit: 14
 
           # for nticks calculation in common/params.jsonnet: elec
@@ -1594,6 +1607,7 @@ dune10kt_dunefd_vertdrift_1x8x14_3view_sim_nfsp : {
             process_crm: "full"
         }
         structs: {
+            elecGain: 7.8 # new default since July 2024
             Nbit: 14
             # number of time samples
             nticks: @local::dunefdvd_detproperties.NumberTimeSamples
@@ -1991,6 +2005,7 @@ dune10kt_horizdrift_sim_nfsp : {
             engine: "TbbFlow"
         }
         structs: {
+          elecGain: 7.8 # new default since July 2024
           Nbit: 14 
           # number of time samples
           nticks: @local::dunefd_detproperties.NumberTimeSamples


### PR DESCRIPTION
Since the refactoring of DUNEWirecell (discussion in #131 ) will probably take some time, I'd like to get in develop at least a patchy update of `Nbit` (aka `resolution`, I kept in the fcl the same name we have in detsim) and `elecGain`. This is very important for trigger validation studies that are ongoing and urgent as of now.

I see that actually [for iceberg it had already been done that some time ago ](https://github.com/DUNE/dunereco/commit/acd361ac211b303c52f3ad3f9602c242423bc4c7) (probably at the same time as when we could/should have been done it for the other dune detectors). It seems to me that, apart from legacy analyses on protodunesp (which would use older dunesw versions anyway, right?), 14 is the standard anywhere now.

The suggestion was to read resolution and gain in `jsonnet`s from fcl, through `extVar`. However, I noticed that resolution is not part of the parameters, rather a local variable, that is defined explicitly only in `json` files. I can add the line `local resolution = std.extVar('Nbit')` to replace `local resolution =params.adc.resolution`, but if things are going to massively change in the future maybe there's no point...?

Cc @jrklein 