### PR TITLE
Turn off pandora validation for ProtoDUNE-HD

### DIFF
--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD_TwoView_APA1.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_HD_TwoView_APA1.xml
@@ -49,7 +49,7 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArTestBeamEventValidation">
+<!--    <algorithm type = "LArTestBeamEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>RecreatedPfos</PfoListName>
@@ -59,6 +59,7 @@
         <OutputTree>Validation</OutputTree>
         <OutputFile>Validation.root</OutputFile>
     </algorithm>
+-->
 <!--   <algorithm type = "LArVisualMonitoring">
         <ShowCurrentPfos>true</ShowCurrentPfos>
         <ShowDetector>true</ShowDetector>


### PR DESCRIPTION
Simple fix to comment out the validation algorithm in Pandora for ProtoDUNE-HD. Just avoids needless debug information in the default workflow.