### PR TITLE
Updating MCS methods

### DIFF
--- a/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/neutrinoenergyrecoalg_dune.fcl
+++ b/dunereco/FDSensOpt/NeutrinoEnergyRecoAlg/neutrinoenergyrecoalg_dune.fcl
@@ -23,18 +23,30 @@ dune_neutrinoenergyrecoalg:
     RecombFactor:            0.63
 
     MCSMethod:              "Chi2"     # Chi2 or "LLHD"
-    MinTrackLengthMCS:      100.       # cm
-    MaxTrackLengthMCS:      1350.      # cm
+    MinTrackLengthMCS:      0.         # cm
+    MaxTrackLengthMCS:      3000.      # cm
     SegmentSizeMCS:         10.        # cm
-    MaxMomentumMCS:         7500       # MeV (integer)
+    MaxMomentumMCS:         100000     # MeV (integer)
     NStepsChi2:             6          # NDF of chi2 fit (integer)
     MinResolutionMCSChi2:   0          # mrad (double) 
-    MaxResolutionMCSChi2:   45         # mrad (double), set zero fixes at minimum
+    MaxResolutionMCSChi2:   0          # mrad (double), set zero fixes at minimum
     MinResolutionMCSLLHD:   0.001      # mrad (double) 
     MaxResolutionMCSLLHD:   800        # mrad (double), set zero fixes at minimum
     CheckValidScattered:    true       # affects LLHD, true will check valid segments for computing scattering
     AngleCorrection:        0.757      # affects LLHD when using space angle. Value set from studies with MC divides scatted angle by 0.757
-    MCSAngleMethod:         1          # scatter angle to use: 1 (xz), 2 (yz) or 3 (space angle)
+    MCSAngleMethod:         3          # scatter angle to use: 1 (xz), 2 (yz) or 3 (space angle)
+}
+
+dune_neutrinoenergyrecoalg_llhd:
+{
+    @table::dune_neutrinoenergyrecoalg
+    MCSMethod: "LLHD"
+    MinTrackLengthMCS: 0
+    MaxTrackLengthMCS: 3000
+    MaxMomentumMCS: 100000
+    MinResolutionMCSLLHD: 0
+    MaxResolutionMCSLLHD: 0
+    MCSAngleMethod: 3
 }
 
 dunevd_neutrinoenergyrecoalg:
@@ -43,9 +55,21 @@ dunevd_neutrinoenergyrecoalg:
     CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
 }
 
+dunevd_neutrinoenergyrecoalg_llhd:
+{
+    @table::dune_neutrinoenergyrecoalg_llhd
+    CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
+}
+
 dunevd_30deg_neutrinoenergyrecoalg:
 {
     @table::dune_neutrinoenergyrecoalg
+    CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
+}
+
+dunevd_30deg_neutrinoenergyrecoalg_llhd:
+{
+    @table::dune_neutrinoenergyrecoalg_llhd
     CalorimetryAlg: @local::dunevd10kt_calorimetryalgmc
 }
 

--- a/dunereco/FDSensOpt/energyreco.fcl
+++ b/dunereco/FDSensOpt/energyreco.fcl
@@ -56,6 +56,12 @@ dunefd_nuenergyreco_pandora_numu_mcs:
     LongestTrackMethod: 2
 }
 
+dunefd_nuenergyreco_pandora_numu_mcs_llhd:
+{
+    @table::dunefd_nuenergyreco_pandora_numu_mcs
+    NeutrinoEnergyRecoAlg: @local::dune_neutrinoenergyrecoalg_llhd
+}
+
 dunefd_nuenergyreco_pandora_nue:
 {
     @table::dunefd_nuenergyreco_pandora_numu
@@ -80,6 +86,10 @@ dunefdvd_nuenergyreco_pandora_numu_mcs: @local::dunefd_nuenergyreco_pandora_numu
 dunefdvd_nuenergyreco_pandora_numu_mcs.NeutrinoEnergyRecoAlg: @local::dunevd10kt_neutrinoenergyrecoalg
 dunefdvd_nuenergyreco_pandora_numu_mcs.HitLabel: "gaushit"
 
+dunefdvd_nuenergyreco_pandora_numu_mcs_llhd: @local::dunefd_nuenergyreco_pandora_numu_mcs_llhd
+dunefdvd_nuenergyreco_pandora_numu_mcs_llhd.NeutrinoEnergyRecoAlg: @local::dunevd_neutrinoenergyrecoalg_llhd
+dunefdvd_nuenergyreco_pandora_numu_mcs_llhd.HitLabel: "gaushit"
+
 dunefdvd_nuenergyreco_pandora_nue:  @local::dunefd_nuenergyreco_pandora_nue
 dunefdvd_nuenergyreco_pandora_nue.NeutrinoEnergyRecoAlg: @local::dunevd10kt_neutrinoenergyrecoalg
 dunefdvd_nuenergyreco_pandora_nue.HitLabel: "gaushit"
@@ -99,6 +109,10 @@ dunefdvd_30deg_nuenergyreco_pandora_numu_range.HitLabel: "gaushit"
 dunefdvd_30deg_nuenergyreco_pandora_numu_mcs: @local::dunefd_nuenergyreco_pandora_numu_mcs
 dunefdvd_30deg_nuenergyreco_pandora_numu_mcs.NeutrinoEnergyRecoAlg: @local::dunevd10kt_30deg_neutrinoenergyrecoalg
 dunefdvd_30deg_nuenergyreco_pandora_numu_mcs.HitLabel: "gaushit"
+
+dunefdvd_30deg_nuenergyreco_pandora_numu_mcs_llhd: @local::dunefd_nuenergyreco_pandora_numu_mcs_llhd
+dunefdvd_30deg_nuenergyreco_pandora_numu_mcs_llhd.NeutrinoEnergyRecoAlg: @local::dunevd_30deg_neutrinoenergyrecoalg_llhd
+dunefdvd_30deg_nuenergyreco_pandora_numu_mcs_llhd.HitLabel: "gaushit"
 
 dunefdvd_30deg_nuenergyreco_pandora_nue:  @local::dunefd_nuenergyreco_pandora_nue
 dunefdvd_30deg_nuenergyreco_pandora_nue.NeutrinoEnergyRecoAlg: @local::dunevd10kt_30deg_neutrinoenergyrecoalg


### PR DESCRIPTION
- Updating the default Chi2 parameters with values that have been shown to perform better (on the atmospheric neutrino sample, but should be generalizable, presentation at https://indico.fnal.gov/event/65965/contributions/298674/attachments/181048/248206/20240826_SimReco_Update_Ereco.pdf)

- Adding a default MCS LLHD configuration that can be used directly by dunesw fcls