### PR TITLE
CVN LBL model for atmospheric neutrios

### DIFF
--- a/dunereco/CVN/fcl/cvn_dune.fcl
+++ b/dunereco/CVN/fcl/cvn_dune.fcl
@@ -113,10 +113,11 @@ dunehd_1x2x6_atmo_cvnevaluator:
         ReverseViews: [false, false, false]
         NImageTDCs: 300
         NImageWires: 300
-        NInputs: 1
+        NInputs: 3
         NOutputs: 3
-        TFBundle: "/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash/CVN/atmos/v01_00_00/dune_cvn_hd_1x2x6_nu_2025_tf217_v01_00_00/"
-        UseBundle: true
+        TFProtoBuf: "/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash/CVN/atmos/v05_00_00/dune_cvn_beamarch_hd_2x6_atmospherics_tf26.pb"
+        TFBundle: ""
+        UseBundle: false
     }
 
 }


### PR DESCRIPTION
After comparisons the LBL CVN architecture improves selection, swithich to the CVN LBL model for atmospherics 