### PR TITLE
Fixing bug where particles with undefined directions were considered

### DIFF
--- a/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.cc
+++ b/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.cc
@@ -423,7 +423,7 @@ Momentum_t NeutrinoAngularRecoAlg::ComputeTracksMomentum(const std::vector<art::
         const recob::Track::Vector_t &dir = pTrack->StartDirection();
 
         if(dir.X() < -1){ //Direction is not defined (-999, -999, -999),
-            continue; //We skip this shower
+            continue; //We skip this track
         }
 
         float momentum_norm = 0;

--- a/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.cc
+++ b/dunereco/FDSensOpt/NeutrinoAngularRecoAlg/NeutrinoAngularRecoAlg.cc
@@ -390,6 +390,11 @@ Momentum_t NeutrinoAngularRecoAlg::ComputeShowersMomentum(const std::vector<art:
     for(const art::Ptr<recob::Shower> &pShower : pShowers){
         float E = GetShowerEnergy(pShower)*1e-3; //Converts from MeV to GeV
         const TVector3 &dir = pShower->Direction();
+
+        if(dir.X() < -1){ //Direction is not defined (-999, -999, -999),
+            continue; //We skip this shower
+        }
+
         momentum.SetX(momentum.X() + E*dir.X());
         momentum.SetY(momentum.Y() + E*dir.Y());
         momentum.SetZ(momentum.Z() + E*dir.Z());
@@ -413,6 +418,12 @@ Momentum_t NeutrinoAngularRecoAlg::ComputeTracksMomentum(const std::vector<art::
         int pid = 0;
         if (tracksPID.count(pTrack) == 1){
             pid = tracksPID.at(pTrack);
+        }
+
+        const recob::Track::Vector_t &dir = pTrack->StartDirection();
+
+        if(dir.X() < -1){ //Direction is not defined (-999, -999, -999),
+            continue; //We skip this shower
         }
 
         float momentum_norm = 0;
@@ -439,10 +450,11 @@ Momentum_t NeutrinoAngularRecoAlg::ComputeTracksMomentum(const std::vector<art::
             momentum_norm = GetTrackKE(fmCal.at(iTrack))*1e-3; //Converts MeV to GeV
             break;
         }
-        const recob::Track::Vector_t &dir = pTrack->StartDirection();
+
         momentum.SetX(momentum.X() + momentum_norm*dir.X());
         momentum.SetY(momentum.Y() + momentum_norm*dir.Y());
         momentum.SetZ(momentum.Z() + momentum_norm*dir.Z());
+
     }
 
     return momentum;


### PR DESCRIPTION
Discarding particles with undefined directions to avoid having them counted with a direction of -1/sqrt(3), which was leading to some statistical peak in that direction.