### PR TITLE
feat: add AdjClusterRad and new cluster configuration for low energy

### DIFF
--- a/dunereco/LowEUtils/PerPlaneCluster.fcl
+++ b/dunereco/LowEUtils/PerPlaneCluster.fcl
@@ -2,8 +2,8 @@ BEGIN_PROLOG
 
 lowe_cluster_dune10kt_1x2x6:
 {
-    HitLabel:           "hitfd"              # The label for the process which ran the Hits
     module_type:        "PerPlaneCluster"
+    HitLabel:           "hitfd"              # The label for the process which ran the Hits
 
     Geometry:                   "HD"
     DetectorSizeY:              600          # 1 TPC Y length in [cm].
@@ -12,6 +12,7 @@ lowe_cluster_dune10kt_1x2x6:
     ClusterAlgoAdjChannel:      3            # Number of adjacent channels to look for plane clusters.
     ClusterChargeVariable:      "Integral"   # Charge variable to use for cluster matching: "Integral" or "SummedADC".
 
+    AdjClusterRad:              100.         # Radius in [cm] to look for adjacent clusters for low energy.
     ClusterMatchNHit:           2            # NHit fraction to match clusters. abs(NHitsCol - NHitsInd) / NHitsCol < ClusterMatchNHit.
     ClusterMatchTime:           20.0         # Time window to look for ind. plane clusters in [tick] units.
     ClusterMatchCharge:         0.6          # Charge fraction to match clusters. abs(ChargeCol - ChargeInd) / ChargeCol < ClusterMatchCharge.
@@ -21,8 +22,12 @@ lowe_cluster_dune10kt_1x2x6:
 }
 
 lowe_cluster_dunevd10kt_1x8x14_3view_30deg: @local::lowe_cluster_dune10kt_1x2x6
+lowe_cluster_dunevd10kt_1x8x14_3view_30deg.HitLabel: "gaushit"
 lowe_cluster_dunevd10kt_1x8x14_3view_30deg.Geometry: "VD"
 lowe_cluster_dunevd10kt_1x8x14_3view_30deg.DetectorSizeY: 680
 lowe_cluster_dunevd10kt_1x8x14_3view_30deg.DetectorSizeZ: 2100
+
+lowe_cluster_dunevd10kt_1x8x6_3view_30deg: @local::lowe_cluster_dunevd10kt_1x8x14_3view_30deg
+lowe_cluster_dunevd10kt_1x8x6_3view_30deg.DetectorSizeZ: 900
 
 END_PROLOG


### PR DESCRIPTION
This pull request updates the configuration file `dunereco/LowEUtils/PerPlaneCluster.fcl` to allow for cluster matching capabilities in FD-VD geometries and introduce new detector configurations. The changes include adding a new parameter for cluster adjacency, updating detector-specific configurations, and ensuring consistency in parameter ordering.

### Enhancements to cluster matching:

* Added `AdjClusterRad` parameter to specify the radius (in cm) for identifying adjacent clusters in low-energy scenarios. (`[dunereco/LowEUtils/PerPlaneCluster.fclR15](diffhunk://#diff-eb50ce280835971435950954797b65dea13b51d9355530aaa5f2dfdd8beca030R15)`)

### Updates to detector configurations:

* Updated the `HitLabel` for `lowe_cluster_dunevd10kt_1x8x14_3view_30deg` to `"gaushit"`, ensuring it aligns with the appropriate hit processing label. (`[dunereco/LowEUtils/PerPlaneCluster.fclR25-R32](diffhunk://#diff-eb50ce280835971435950954797b65dea13b51d9355530aaa5f2dfdd8beca030R25-R32)`)
* Introduced a new detector configuration, `lowe_cluster_dunevd10kt_1x8x6_3view_30deg`, based on the existing `lowe_cluster_dunevd10kt_1x8x14_3view_30deg`, with a modified `DetectorSizeZ` of 900 cm. (`[dunereco/LowEUtils/PerPlaneCluster.fclR25-R32](diffhunk://#diff-eb50ce280835971435950954797b65dea13b51d9355530aaa5f2dfdd8beca030R25-R32)`)

### Consistency improvements:

* Reordered the `HitLabel` parameter in `lowe_cluster_dune10kt_1x2x6` for better readability and consistency with other parameters. (`[dunereco/LowEUtils/PerPlaneCluster.fclL5-R6](diffhunk://#diff-eb50ce280835971435950954797b65dea13b51d9355530aaa5f2dfdd8beca030L5-R6)`)