### PR TITLE
Fix AnaUtils PFO methods

### DIFF
--- a/dunereco/AnaUtils/CMakeLists.txt
+++ b/dunereco/AnaUtils/CMakeLists.txt
@@ -1,4 +1,4 @@
-art_make( 
+art_make(
     LIB_LIBRARIES larcorealg::Geometry
     larcore::Geometry_Geometry_service
     larsim::Simulation lardataobj::Simulation
@@ -7,6 +7,7 @@ art_make(
     lardataobj::RecoBase
     lardataobj::AnalysisBase
     lardata::Utilities
+    larpandora::LArPandoraInterface
     nusimdata::SimulationBase
     ROOT::Core
     art::Persistency_Common

--- a/dunereco/AnaUtils/DUNEAnaPFParticleUtils.cxx
+++ b/dunereco/AnaUtils/DUNEAnaPFParticleUtils.cxx
@@ -22,6 +22,7 @@
 #include "lardataobj/RecoBase/PFParticle.h"
 #include "lardataobj/RecoBase/PFParticleMetadata.h"
 #include "lardataobj/AnalysisBase/T0.h"
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
 
 namespace dune_ana
 {
@@ -166,8 +167,12 @@ bool DUNEAnaPFParticleUtils::IsTrack(const art::Ptr<recob::PFParticle> &pParticl
 {
     // This function needs to fail if GetTrack would fail
     const std::vector<art::Ptr<recob::Track>> theseTracks = DUNEAnaPFParticleUtils::GetAssocProductVector<recob::Track>(pParticle,evt,particleLabel,trackLabel);
+    if (theseTracks.empty())
+    {
+        return false;
+    }
 
-    return !theseTracks.empty();
+    return lar_pandora::LArPandoraHelper::IsTrack(pParticle);
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
@@ -175,8 +180,12 @@ bool DUNEAnaPFParticleUtils::IsTrack(const art::Ptr<recob::PFParticle> &pParticl
 bool DUNEAnaPFParticleUtils::IsShower(const art::Ptr<recob::PFParticle> &pParticle, const art::Event &evt, const std::string &particleLabel, const std::string &showerLabel)
 {
     const std::vector<art::Ptr<recob::Shower>> theseShowers = DUNEAnaPFParticleUtils::GetAssocProductVector<recob::Shower>(pParticle,evt,particleLabel,showerLabel);
-   
-    return !theseShowers.empty();
+    if (theseShowers.empty())
+    {
+        return false;
+    }
+
+    return lar_pandora::LArPandoraHelper::IsShower(pParticle);
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
IsTrack/IsShower expected existence of Track/Shower object to mean the pfo is track/shower. This is no longer the case since we a recob::Shower and recob::Track for each PFParticle object. Fix: Add a check that uses the PDG code given to the PFParticle by pandoa.