### PR TITLE
Add pandora config for PDVD nu trigger

### DIFF
--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_VD_Neutrino.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Master_ProtoDUNE_VD_Neutrino.xml
@@ -26,14 +26,7 @@
             <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>false</ThreeDStitchingMode></tool>
         </StitchingTools>
         <CosmicRayTaggingTools>
-	    <!-- <tool type = "LArCosmicRayTagging"/> -->
-            <tool type = "LArTestBeamCosmicRayTagging">
-                <TagTopEntering>true</TagTopEntering>
-                <TagTopToBottom>true</TagTopToBottom>
-                <TagIsOutOfTime>true</TagIsOutOfTime>
-                <TagInVetoedTPCs>true</TagInVetoedTPCs>
-                <!--<VetoedTPCs>2 6</VetoedTPCs>-->
-            </tool>
+	    <tool type = "LArCosmicRayTagging"/>
         </CosmicRayTaggingTools>
         <SliceIdTools>
 		<tool type = "LArSimpleNeutrinoId"/>


### PR DESCRIPTION
New pandora config to optimize the neutrino reconstruction by pandora for PDVD.
Based on the `PandoraSettings_Master_ProtoDUNE_HD_neutrino.xml` config file.

Comes along with PR https://github.com/DUNE/dunesw/pull/217

In particular, called in this file: https://github.com/DUNE/dunesw/blob/5f6aba25aeb69fc08e52f3b2ff13aff679c01b40/fcl/protodunevd/reco/standard_reco_stage1_protodunevd_neutrino.fcl