### PR TITLE
Update PDHD WireCell max_rms_cut configuration

### DIFF
--- a/dunereco/DUNEWireCell/pdhd/chndb-base.jsonnet
+++ b/dunereco/DUNEWireCell/pdhd/chndb-base.jsonnet
@@ -48,7 +48,7 @@ function(params, anode, field, n, rms_cuts=[])
         min_adc_limit: 200, // 50,
         roi_min_max_ratio: 0.8, // default 0.8
         min_rms_cut: 1.0,  // units???
-        max_rms_cut: 30.0,  // units???
+        max_rms_cut: 50.0,  // units???
 
         // parameter used to make "rcrc" spectrum
         rcrc: 1.1 * wc.millisecond, // 1.1 for collection, 3.3 for induction


### PR DESCRIPTION
The previous max_rms_cut value was set to 30.0.

The configuration is updated here to increase max_rms_cut from 30.0 to 50.0 so that channels with RMS above 30, but without significant impact on the DNN-based signal processing, can still be retained.

Key changes:
Update max_rms_cut from 30.0 to 50.0 in chndb-base.jsonnet