### PR TITLE
fix the simchannelIDE energy issue

### DIFF
--- a/dunereco/DUNEWireCell/dune10kt-1x2x6/wcls-sim-drift-simchannel-nf-sp.jsonnet
+++ b/dunereco/DUNEWireCell/dune10kt-1x2x6/wcls-sim-drift-simchannel-nf-sp.jsonnet
@@ -256,7 +256,7 @@ local wcls_depoflux_writer = g.pnode({
     window_duration: self.tick * 6000,
     nsigma: 3.0,
     reference_time: fcl_params.G4RefTime,
-    energy: 1, # equivalent to use_energy = true
+    energy: 0,
     simchan_label: 'simpleSC',
     sed_label: 'IonAndScint',
     sparse: false,

--- a/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
+++ b/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
@@ -180,7 +180,7 @@ local wcls_depoflux_writer = g.pnode({
     window_duration: self.tick * 6000,
     nsigma: 3.0,
     reference_time: -250 * wc.us,
-    energy: 0, # equivalent to use_energy = true
+    energy: 0, 
     simchan_label: 'simpleSC',
     sed_label: 'IonAndScint',
     sparse: false,

--- a/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
+++ b/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
@@ -180,7 +180,7 @@ local wcls_depoflux_writer = g.pnode({
     window_duration: self.tick * 6000,
     nsigma: 3.0,
     reference_time: -250 * wc.us,
-    energy: 1, # equivalent to use_energy = true
+    energy: 0, # equivalent to use_energy = true
     simchan_label: 'simpleSC',
     sed_label: 'IonAndScint',
     sparse: false,

--- a/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
+++ b/dunereco/DUNEWireCell/pdhd/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
@@ -180,7 +180,7 @@ local wcls_depoflux_writer = g.pnode({
     window_duration: self.tick * 6000,
     nsigma: 3.0,
     reference_time: -250 * wc.us,
-    energy: 0, 
+    energy: 0,
     simchan_label: 'simpleSC',
     sed_label: 'IonAndScint',
     sparse: false,

--- a/dunereco/DUNEWireCell/pdsp/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
+++ b/dunereco/DUNEWireCell/pdsp/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
@@ -181,7 +181,7 @@ local wcls_depoflux_writer = g.pnode({
     window_duration: self.tick * 6000,
     nsigma: 3.0,
     reference_time: -250 * wc.us,
-    energy: 0, 
+    energy: 0,
     simchan_label: 'simpleSC',
     sed_label: 'IonAndScint',
     sparse: false,

--- a/dunereco/DUNEWireCell/pdsp/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
+++ b/dunereco/DUNEWireCell/pdsp/wcls-sim-drift-simchannel-priorSCE-depoflux.jsonnet
@@ -181,7 +181,7 @@ local wcls_depoflux_writer = g.pnode({
     window_duration: self.tick * 6000,
     nsigma: 3.0,
     reference_time: -250 * wc.us,
-    energy: 1, # equivalent to use_energy = true
+    energy: 0, 
     simchan_label: 'simpleSC',
     sed_label: 'IonAndScint',
     sparse: false,

--- a/dunereco/DUNEWireCell/protodunevd/wcls-sim-drift-depoflux.jsonnet
+++ b/dunereco/DUNEWireCell/protodunevd/wcls-sim-drift-depoflux.jsonnet
@@ -185,7 +185,7 @@ local wcls_depoflux_writer = g.pnode({
     window_duration: self.tick * 6000,
     nsigma: 3.0,
     reference_time: -250 * wc.us,
-    energy: 1, # equivalent to use_energy = true
+    energy: 0,
     simchan_label: 'simpleSC',
     sed_label: 'IonAndScint',
     sparse: false,


### PR DESCRIPTION
Setting energy: 1 in wclsDepoFluxWriter caused every depo to be assigned a hardcoded energy regardless of true deposited energy. Setting energy: 0 correctly reads the truth energy from depo->prior()->energy().
```
https://github.com/WireCell/wire-cell-toolkit/issues/470
Please refer to this issue, and discussions
```