### PR TITLE
Fix missing flag in VD pandora dl shower growing xml

### DIFF
--- a/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD_VD.xml
+++ b/dunereco/DUNEPandora/scripts/PandoraSettings_Neutrino_DUNEFD_VD.xml
@@ -147,6 +147,7 @@
         <SimilarityThreshold>0.60</SimilarityThreshold>
         <SimilarityThresholdBeta>1.0</SimilarityThresholdBeta>
         <AccessoryClusterMaxHits>2</AccessoryClusterMaxHits>
+        <IncludeDistToXGapFeature>false</IncludeDistToXGapFeature>
         <MaxIterations>10</MaxIterations>
         <PolarRScaleFactor>0.0005742559</PolarRScaleFactor>
         <CartesianXScaleFactor>0.001538462</CartesianXScaleFactor>


### PR DESCRIPTION
I somehow failed to include this flag when originally updating the xmls to include the new DL shower growing in PR #184 .

Without this flag the alg fails as it is trying to form a feature based on an x gap that does not exist in the reduced VD geometry...